### PR TITLE
Upstream updates

### DIFF
--- a/usr/sbin/pkg
+++ b/usr/sbin/pkg
@@ -6332,7 +6332,7 @@ get_deps(){                       # find, get and install the deps of pkgname ($
   local pkg_is_builtin=`is_builtin_pkg "$PKGNAME_ONLY" 2>/dev/null`
   local pkg_already_done=`LANG=C grep -m1 "^$PKGNAME_ONLY\$" $TMPDIR/PKGSDONE 2>/dev/null`
 
-  local pkg_is_blacklisted=`is_blacklisted_pkg "$PKG_NAME_ONLY" 2>/dev/null`
+  local pkg_is_blacklisted=`is_blacklisted_pkg "$PKGNAME_ONLY" 2>/dev/null`
 
   # if pkg is builtin, skip it, we dont need to get its dependencies
   [ "$pkg_is_builtin" = true -a "$HIDE_BUILTINS" = true ] && continue

--- a/usr/sbin/pkg
+++ b/usr/sbin/pkg
@@ -24,13 +24,12 @@
 
 APPNAME="Pkg"
 APPVER="1.9.23"
-APPTITLE="$APPNAME $APPVER"
 
 # get current locale settings
 USER_LANG=$LANG
 USER_LC_ALL=$LC_ALL
 
-SELF=$(basename $0)        # this script
+SELF=$(basename "$0")      # this script
 QTAG=''                    # gets set to (y/n) if ASK=-true
 LANG=C                     # speed up
 LC_ALL=C                   # speed up
@@ -38,6 +37,8 @@ EDITOR=${EDITOR:-vi}       # just in case
 PAGER=${PAGER:-less}       # just in case
 CURDIR="${PWD}"            # get current dir, before cd to WORKDIR
 TMPDIR=/tmp/pkg/${whoami}  # set the tmp dir
+#run as root only
+whoami=$(whoami)
 
 # set colours true by default
 green="\e[32m"; red="\e[91m"; magenta="\e[95m"; lightblue="\e[36m"; yellow="\e[93m"; bold="\e[1m"; endcolour="\e[0m"
@@ -56,10 +57,10 @@ green="\e[32m"; red="\e[91m"; magenta="\e[95m"; lightblue="\e[36m"; yellow="\e[9
 [ -z "$PKG_CONFIGURE"  ] && export PKG_CONFIGURE=''     # reset
 [ -z "$PKG_CFLAGS"     ] && export PKG_CFLAGS=''        # reset
 [ -z "$PKG_BLACKLIST"  ] && export PKG_BLACKLIST=''     # reset
-[ -z "$PKG_PPA2PUP_FN" ] && if [ ! -z "`which gawk`" ]; then PKG_PPA2PUP_FN=ppa2pup_gawk; else PKG_PPA2PUP_FN=ppa2pup; fi
+[ -z "$PKG_PPA2PUP_FN" ] && if [ ! -z "$(which gawk)" ]; then PKG_PPA2PUP_FN=ppa2pup_gawk; else PKG_PPA2PUP_FN=ppa2pup; fi
 
 # but disable colours if called as gpkg, or the ENV variable PKG_NO_COLOURS is true
-if [ "`basename $0`" != "pkg" -o "$PKG_NO_COLOURS" = true ];then
+if [ "$SELF" != "pkg" ] || [ "$PKG_NO_COLOURS" = true ];then
   green='' red='' magenta='' lightblue='' yellow='' bold='' endcolour=''
 fi
 
@@ -70,11 +71,14 @@ error(){
 
 # for correct error output, trap commands early
 cleanup(){
+  # shellcheck disable=SC2086
   rm -f ${TMPDIR}/missing_dep* ${TMPDIR}/installed_pkg* ${TMPDIR}/all_dep* ${TMPDIR}/DEP_DONE /tmp/pkg/list_deps_busy ${TMPDIR}/pkg_file_list ${TMPDIR}/dependents_list ${TMPDIR}/DEP_DONE ${TMPDIR}/ldd_file_list &>/dev/null
   rm -rf /tmp/pkg/build_pkg/ &>/dev/null
 
   # prevent double msg output if error=130 (user Ctrl-C)
-  [ -f /tmp/pkg/error130 -a "$2" = '130' ] && exit "$2"
+  if [ -f /tmp/pkg/error130 ] && [ "$2" = '130' ];then
+    exit "$2"
+  fi
   # make the tmp dir we'll use
   mkdir -p /tmp/pkg &>/dev/null
   # only add line numbers if it was given
@@ -93,17 +97,15 @@ cleanup(){
   *)   msg="Error code = $2" ;;
   esac
   # print msg
-  [ "$2" != "0" ]  && echo -e 1>&2 "${red}Error${endcolour} ${2}: ${lineno}$msg"
-  exit $2
+  [ "$2" != "0" ] && echo -e 1>&2 "${red}Error${endcolour} ${2}: ${lineno}$msg"
+  exit "$2"
 }
 trap 'cleanup ${LINENO:-none} $?' EXIT INT TERM
 
-#run as root only
-whoami=$(whoami)
 [ "$whoami" != "root" ] && echo "You must be root to run Pkg." && exit 1
 
 #080413 make sure all config files are present, copy from /etc if need be
-if [ ! -f ${PKGRC} ];then
+if [ ! -f "${PKGRC}" ];then
   echo "Restoring default settings from /etc/pkg"
   [ ! -d /etc/pkg/ ] && error "Default config files  in /etc/pkg/ not found." && exit 3
   mkdir -p "$HOME/.pkg"
@@ -132,8 +134,10 @@ case "$DISTRO_TARGETARCH" in
   armhf)  DBIN_ARCH=armh   ; DSUFFIX=64 ;;
   *)      DBIN_ARCH=i486                ;;
 esac
+export DSUFFIX;
 
 # set correct package name/version separator (helps resolve package names)
+separator='_'
 case $DISTRO_BINARY_COMPAT in
   ubuntu|trisquel|debian|devuan)
     separator='_'
@@ -142,6 +146,7 @@ case $DISTRO_BINARY_COMPAT in
     separator='-'
     ;;
 esac
+export separator
 
 # needed for some debian based repos
 case $DISTRO_COMPAT_VERSION in
@@ -149,9 +154,10 @@ case $DISTRO_COMPAT_VERSION in
   *)      DDB_COMP=xz  ;;
 esac
 
-# 0setup must be used differently in older and newer Woof-CE versions, so 
+# 0setup must be used differently in older and newer Woof-CE versions, so
 # check which version of 0setup we're using, then set a flag on how to use it
 PKG_REPO_UPDATE_METHOD=${PKG_REPO_UPDATE_METHOD:-standard}
+# shellcheck disable=SC2016
 if [ "$(grep -m1 'if \[ -d ./support -a -f ./DISTRO_SPECS -a -d ./rootfs-skeleton \] ;then' /usr/local/petget/0setup)" = "" ] && \
    [ "$(grep -m1 'if \[ "$RUNNINGPUP" = "yes" \];then' /usr/local/petget/0setup)" != "" ]
 then
@@ -170,7 +176,7 @@ else
 fi
 
 # set $DIRECTSAVEPATH (where we want to install pkgs)
-if [ $PUPMODE -eq 3 -o $PUPMODE -eq 7 -o $PUPMODE -eq 13 ];then
+if [ $PUPMODE -eq 3 ] || [ $PUPMODE -eq 7 ] || [ $PUPMODE -eq 13 ];then
   DIRECTSAVEPATH="/initrd${SAVE_LAYER}" #SAVE_LAYER is in /etc/rc.d/PUPSTATE.
 elif [ "$PUPMODE" = "2" ]; then
   DIRECTSAVEPATH=""
@@ -192,10 +198,11 @@ WORKDIR=~/pkg
 if [ -z "$PKG_TAB_COMPLETION" ];then
   if [ "$(grep 'export PKG_TAB_COMPLETION=true' ~/.bashrc)" = "" ];then
     # add to bashrc
-    echo "" >> ~/.bashrc
-    echo "# enable $APPNAME $APPVER TAB completion" >> ~/.bashrc
-    echo "export PKG_TAB_COMPLETION=true" >> ~/.bashrc
-    echo ". /etc/bash_completion.d/pkg 2>/dev/null" >> ~/.bashrc
+    { echo ""
+      echo "# enable $APPNAME $APPVER TAB completion"
+      echo "export PKG_TAB_COMPLETION=true"
+      echo "source /etc/bash_completion.d/pkg 2>/dev/null"
+    } >> ~/.bashrc
   fi
 fi
 
@@ -221,12 +228,11 @@ xdg_puppy,xdg-utils
 perl_tiny,perl-base,perl-modules,perlapi*'
 [ ! -f "$TMPDIR/pkg_aliases" ] && echo "$PKG_NAME_ALIASES" > $TMPDIR/pkg_aliases
 
-# get blacklisted packages (each on new line) from $PKG_NAME_IGNORE 
+# get blacklisted packages (each on new line) from $PKG_NAME_IGNORE
 # and ~/.pkg/blacklisted_packages .. exports $PKG_BLACKLIST
 get_blacklist(){
 
   PKG_BLACKLIST="$(echo "$PKG_BLACKLIST $PKG_NAME_IGNORE $(cat ${HOME}/.pkg/blacklisted_packages 2>/dev/null)" \
-    | grep -v "^$" \
     | tr ' ' '\n' \
     | grep -v ^$ \
     | sort -u)"
@@ -237,13 +243,13 @@ get_blacklist(){
 get_blacklist
 # create a list like "foo|bar|baz", to be used in grep commands
 PKG_BLACKLIST_REGEX="$(echo "$PKG_BLACKLIST" | tr '\n' '|' | sed -e 's/^|//' -e 's/|$//')"
-export PKG_BLACKLIST_REGEX 
+export PKG_BLACKLIST_REGEX
 
 # remove error code flag if we got here
 rm -f /tmp/pkg/error130 &>/dev/null
 
 # if not first run, and no options given, print the help
-[ ! -f ~/.pkg/firstrun -a "$1" = "" ] && $SELF -H && exit 1 #200913 more help by default
+[ ! -f ~/.pkg/firstrun ] && [ "$1" = "" ] && $SELF -H && exit 1 #200913 more help by default
 }
 #==================  setup script vars  =====================#
 
@@ -259,14 +265,14 @@ print_usage(){                    # print usage text. Requires $1, a valid Pkg c
 
   local examples_file=/usr/share/pkg/docs/examples.txt
 
-  [ -f $examples_file ] && source $examples_file
+  [ -f "$examples_file" ] && source "$examples_file"
 
   # get and print the usage info from its usage file
-  if [ -f /usr/share/pkg/docs/usage/$1 -a "$1" ];then
+  if [ -f /usr/share/pkg/docs/usage/$1 ] && [ "$1" ];then
     source /usr/share/pkg/docs/usage/$1
     echo -e "\n$USAGE"
     # show examples, taken from $EXAMPLES, if they exist
-    if [ "`echo "$EXAMPLES" | grep "$SELF" | grep "\-$1"`" != '' ];then
+    if [ "$(echo "$EXAMPLES" | grep "$SELF" | grep "\-$1")" != '' ];then
       echo -e "\n${bold}Usage Examples${endcolour}:\n"
       echo -e "$EXAMPLES" | grep "$SELF " | grep "$1 "
     fi
@@ -309,48 +315,59 @@ Usage: ${bold}$SELF usage CMD${endcolour}"
 
 
 func_list(){                      # list all functions available in this script FUNCLIST
-  [ -f $TMPDIR/func_list ] && cat $TMPDIR/func_list | sort && exit 0
-  grep "(){" $0 | grep '#' | grep FUNCLIST | sed -e 's|^| |g' -e 's|{||g' -e 's|  | |g' -e 's|# ||g' -e 's| FUNCLIST||g' | grep -v 'FUNCLIST $0' | sort > $TMPDIR/func_list
-  cat $TMPDIR/func_list | sort
+  [ -f $TMPDIR/func_list ] && sort $TMPDIR/func_list && exit 0
+  # shellcheck disable=SC2016
+  grep "(){" $0 | grep '#'    \
+    | grep FUNCLIST           \
+    | sed -e 's|^| |g'        \
+          -e 's|{||g'         \
+          -e 's|  | |g'       \
+          -e 's|# ||g'        \
+          -e 's| FUNCLIST||g' \
+    | grep -v 'FUNCLIST $0'   \
+    | sort > $TMPDIR/func_list
+
+  cat $TMPDIR/func_list
   exit 0
 }
+
 
 update_system_cache() {
   # $1 = PKGFILES [ex: /root/.packages/abiword.files]
   local PKGFILES=$1
 
-  if grep -q -m 1 '/usr/share/glib-2.0/schemas' $PKGFILES ; then
+  if grep -q -m 1 '/usr/share/glib-2.0/schemas' "$PKGFILES" ;then
     if [ -e /usr/bin/glib-compile-schemas ] ; then
       /usr/bin/glib-compile-schemas /usr/share/glib-2.0/schemas
     fi
   fi
 
-  if grep -q -m 1 '/usr/lib/gio/modules' $PKGFILES ; then
+  if grep -q -m 1 '/usr/lib/gio/modules' "$PKGFILES" ;then
     if [ -e /usr/bin/gio-querymodules ] ; then
       /usr/bin/gio-querymodules /usr/lib/gio/modules
     fi
   fi
 
-  if grep -q -m 1 '/usr/share/applications/' $PKGFILES ; then
+  if grep -q -m 1 '/usr/share/applications/' "$PKGFILES" ;then
     if [ -e /usr/bin/update-desktop-database ] ; then
       rm -f /usr/share/applications/mimeinfo.cache
       /usr/bin/update-desktop-database /usr/share/applications
     fi
   fi
 
-  if grep -q -m 1 '/usr/share/mime/' $PKGFILES ; then
+  if grep -q -m 1 '/usr/share/mime/' "$PKGFILES" ;then
     if [ -e /usr/bin/update-mime-database ] ; then
       /usr/bin/update-mime-database /usr/share/mime
     fi
   fi
 
-  if grep -q -m 1 '/usr/share/icons/hicolor/' $PKGFILES ; then
+  if grep -q -m 1 '/usr/share/icons/hicolor/' "$PKGFILES" ;then
     if [ -e /usr/bin/gtk-update-icon-cache ] ; then
       /usr/bin/gtk-update-icon-cache /usr/share/icons/hicolor
     fi
   fi
 
-  if grep -q -m 1 '/usr/lib/gdk-pixbuf' $PKGFILES ; then
+  if grep -q -m 1 '/usr/lib/gdk-pixbuf' "$PKGFILES" ;then
     if [ -e /usr/bin/update-gdk-pixbuf-loaders ] ; then
       update-gdk-pixbuf-loaders
     elif [ -e /usr/bin/gdk-pixbuf-query-loaders ] ; then
@@ -358,11 +375,11 @@ update_system_cache() {
     fi
   fi
 
-  if grep -q -m 1 '/usr/lib/gconv/' $PKGFILES ; then
+  if grep -q -m 1 '/usr/lib/gconv/' "$PKGFILES" ;then
     iconvconfig
   fi
 
-  if grep -q -m 1 '/usr/lib/pango/' $PKGFILES; then
+  if grep -q -m 1 '/usr/lib/pango/' "$PKGFILES"; then
     if [ -e /usr/bin/update-pango-querymodules ] ; then
       update-pango-querymodules
     elif [ -e /usr/bin/pango-querymodules ] ; then
@@ -370,7 +387,7 @@ update_system_cache() {
     fi
   fi
 
-  if grep -m 1 "/usr/lib/gtk-2.0" $PKGFILES | grep -q "/immodules" ; then
+  if grep -m 1 "/usr/lib/gtk-2.0" "$PKGFILES" |grep -q "/immodules" ; then
     if [ -e /usr/bin/update-gtk-immodules-2.0 ] ; then
       update-gtk-immodules-2.0
     elif [ -e /usr/bin/gtk-query-immodules-2.0 ] ; then
@@ -378,7 +395,7 @@ update_system_cache() {
     fi
   fi
 
-  if grep -m 1 "/usr/lib/gtk-3.0" $PKGFILES | grep -q "/immodules" ; then
+  if grep -m 1 "/usr/lib/gtk-3.0" "$PKGFILES" |grep -q "/immodules" ; then
     if [ -e /usr/bin/update-gtk-immodules-3.0 ] ; then
       update-gtk-immodules-3.0
     elif [ -e /usr/bin/gtk-query-immodules-3.0 ] ; then
@@ -386,11 +403,11 @@ update_system_cache() {
     fi
   fi
 
-  if grep -q -m 1 '/usr/share/fonts/' $PKGFILES ; then
+  if grep -q -m 1 '/usr/share/fonts/' "$PKGFILES" ;then
     fc-cache -f
   fi
 
-  if grep -q -m 1 "/lib/modules/$(uname -r)/" $PKGFILES ; then
+  if grep -q -m 1 "/lib/modules/$(uname -r)/" "$PKGFILES" ;then
     depmod -a
   fi
 }
@@ -433,17 +450,18 @@ get_pkg_ext(){                    # return file extension of $1 FUNCLIST
     *)
       # no extension given, or extension not recognised, so..
       # if it's an installed pkg, get the extension from $HOME/.packages/*
-      pkg_installed=`list_installed_pkgs "$1" | grep -m1 "^$1"`
+      pkg_installed=$(list_installed_pkgs "$1" | grep -m1 "^$1")
 
       # if $pkg_check not empty, then $1 is an installed pkg
       if [ "$pkg_installed" != '' ];then
-        pkg_filename=`cut -f8 -d'|' $HOME/.packages/user-installed-packages |grep -m1 ^$1`
-        [ "$pkg_filename" = '' ] && pkg_filename=`cut -f8 -d'|' $HOME/.packages/*-installed-packages |grep -m1 ^$1`
-        [ "$pkg_filename" != '' ] && pkg_ext=`get_pkg_ext "$pkg_filename"`
+        pkg_filename=$(cut -f8 -d'|' $HOME/.packages/user-installed-packages |grep -m1 "^$1")
+        [ "$pkg_filename"  = '' ] && pkg_filename=$(cut -f8 -d'|' $HOME/.packages/*-installed-packages |grep -m1 "^$1")
+        [ "$pkg_filename" != '' ] && pkg_ext=$(get_pkg_ext "$pkg_filename")
       else
         # if it's a repo package, get it's extension from $HOME/.packages/*
-        pkg_filename=`grep -m1 "^$1" $HOME/.packages/Packages-* |cut -f8 -d'|'`
-       [ "$pkg_filename" != '' ] &&  pkg_ext=`get_pkg_ext "$pkg_filename"`
+        # shellcheck disable=SC2086
+        pkg_filename=$(grep -m1 "^$1" $HOME/.packages/Packages-* |cut -f8 -d'|')
+       [ "$pkg_filename" != '' ] && pkg_ext=$(get_pkg_ext "$pkg_filename")
       fi
       [ "$pkg_ext" != '' ] && echo $pkg_ext
       ;;
@@ -456,46 +474,55 @@ get_pkg_version(){                # returns version of PKGNAME ($1) FUNCLIST
   # exit if no pkg given
   [ ! "$1" ] && exit 1
 
-  local PKGNAME=`get_pkg_name "$1"`
-  local PKGNAME_ONLY=`get_pkg_name_only "$PKGNAME"`
-  local pkg_ext=`get_pkg_ext "$PKGNAME"`
-  local pkg_version=''
+  local PKGNAME PKGNAME_ONLY PKG_VERSION
+ 
+  PKGNAME=$(get_pkg_name "$1")
+  PKGNAME_ONLY=$(get_pkg_name_only "$PKGNAME")
 
-  PKGNAME=$(basename "$PKGNAME" .$pkg_ext)
+  PKG_VERSION="$(grep -m1 "^$PKGNAME|" $HOME/.packages/user-installed-packages | cut -f3 -d'|')"
+  # cut pkg name only off start (field 3 of user-installed-packges might have full nanes, not versions)
+  PKG_VERSION="${PKG_VERSION/${PKGNAME_ONLY}${separator}/}"
+ 
+  
+  if [ -z "$PKG_VERSION" ];then
+    PKG_VERSION="$(grep -m1 "^$PKGNAME|" ~/.packages/Packages-* | cut -f3 -d'|')"
+  fi
 
-  pkg_version=`echo $PKGNAME | sed -e "s/^${PKGNAME_ONLY}_//g"`
-  # if $pkg_version is same as $PKGNAME, try cutting again, using '-' instead of '_'
-  [ "$pkg_version" = "$PKGNAME" ] && pkg_version=`echo $PKGNAME | sed -e "s/^${PKGNAME_ONLY}${separator}//g"`
-  [ "$pkg_version" = "$PKGNAME" ] && pkg_version=`echo $PKGNAME | sed -e "s/^${PKGNAME_ONLY}-//g"`
-  [ "$pkg_version" = "$PKGNAME" ] && pkg_version=`echo $PKGNAME | sed -e "s/^${PKGNAME_ONLY}_//g"`
+  if [ -z "$PKG_VERSION" ];then
+    PKG_VERSION="$(grep -m1 "|$PKGNAME_ONLY|" ~/.packages/Packages-* | cut -f3 -d'|')"
+  fi
 
-  # now trim off the other unneeded bits
-  pkg_version=`echo  $pkg_version | sed \
-    -e "s/^-//g" \
-    -e "s/^_//g" \
-    -e "s/^DEV-//g" \
-    -e "s/^DOC-//g" \
-    -e "s/^NLS-//g" \
-    -e "s/^dev-//g" \
-    -e "s/^doc-//g" \
-    -e "s/^nls-//g" \
-    -e "s/+deb.*//g" \
-    -e "s/+ubuntu.*//g" \
-    -e "s/-i[346].*//g" \
-    -e "s/-x[86].*//g" \
-    -e "s/-pup.*//g" \
-    -e "s/-q[0-9].*//g" \
-    -e "s/-WITHDEPS.*//g" \
-    -e "s/-PLUSDEPS.*//g" \
-    -e 's@\\\@@g'`
+  if [ -z "$PKG_VERSION" ];then
+    PKG_VERSION="$(grep -m1 "^$PKGNAME" ~/.packages/Packages-* | cut -f3 -d'|')"
+  fi
 
-  # get $REPONAME and $EX
-  . ${PKGRC}
+  if [ -z "$PKG_VERSION" ];then
+    PKG_VERSION="${PKGNAME/${PKGNAME_ONLY}${separator}/}"
+    # shellcheck disable=SC2006
+    PKG_VERSION=`echo  "$PKG_VERSION" \
+      | sed \
+        -e "s/^-//g" \
+        -e "s/^_//g" \
+        -e "s/^DEV-//g" \
+        -e "s/^DOC-//g" \
+        -e "s/^NLS-//g" \
+        -e "s/^dev-//g" \
+        -e "s/^doc-//g" \
+        -e "s/^nls-//g" \
+        -e "s/+deb.*//g" \
+        -e "s/+ubuntu.*//g" \
+        -e "s/-i[346].*//g" \
+        -e "s/-x[86].*//g" \
+        -e "s/-pup.*//g" \
+        -e "s/-q[0-9].*//g" \
+        -e "s/${CP_SUFFIX}.*//g" \
+        -e "s/-WITHDEPS.*//g" \
+        -e "s/-PLUSDEPS.*//g" \
+        -e 's@\\\@@g'`
+  fi
 
-  [ "$pkg_ext" = '' ] && pkg_ext=$EX
-
-  echo $pkg_version
-  return 0
+  [ ! -z "$PKG_VERSION" ] && echo "$PKG_VERSION" && return 0
+  return 1
 }
 
 
@@ -505,9 +532,9 @@ get_pkg_name_only_from_ext(){     # return package name from $1 (must include fi
   [ ! "$1" ] && echo 'Usage: get_pkg_name_only_from_ext <PKG_FILENAME>' && exit 1
 
   # get the extension of the given package name, if any
-  local pkg_ext=`get_pkg_ext "$1"`
+  local pkg_ext=$(get_pkg_ext "$1")
   # get the name without path and extension
-  local pkg_name=`basename "$1" .$pkg_ext`
+  local pkg_name=$(basename "$1" ".$pkg_ext")
   local PKGNAME=''
   local PKGNAME_ONLY=''
   local DB_pkgrelease=''
@@ -520,44 +547,44 @@ get_pkg_name_only_from_ext(){     # return package name from $1 (must include fi
   case $pkg_ext in
     deb)
      #deb ex: xsltproc_1.1.24-1ubuntu2_i386.deb  xserver-common_1.5.2-2ubuntu3_all.deb
-     PKGNAME_ONLY="`echo -n "$pkg_name" | cut -f 1 -d '_'`"
-     DB_pkgrelease="`echo -n "$pkg_name" | rev | cut -f 2 -d '_' | cut -f 1 -d '-' | rev`"
+     PKGNAME_ONLY="$(echo -n "$pkg_name" | cut -f 1 -d '_')"
+     DB_pkgrelease="$(echo -n "$pkg_name" | rev | cut -f 2 -d '_' | cut -f 1 -d '-' | rev)"
      prPATTERN="s%\\-${DB_pkgrelease}.*%%"
-     PKGNAME="`echo -n "$pkg_name" | sed -e "$prPATTERN" 2>/dev/null`"
+     PKGNAME="$(echo -n "$pkg_name" | sed -e "$prPATTERN" 2>/dev/null)"
     ;;
     pet)
      PKGNAME="$pkg_name"
-     DB_version="`echo -n "$PKGNAME" | grep -o '\\-[0-9].*' | sed -e 's%^\-%%'`"
-     xDB_version="`echo -n "$DB_version" | sed -e 's%\\-%\\\\-%g' -e 's%\\.%\\\\.%g'`"
+     DB_version="$(echo -n "$PKGNAME" | grep -o '\\-[0-9].*' | sed -e 's%^\-%%')"
+     xDB_version="$(echo -n "$DB_version" | sed -e 's%\\-%\\\\-%g' -e 's%\\.%\\\\.%g')"
      xPATTERN="s%${xDB_version}%%"
-     PKGNAME_ONLY="`echo -n "$PKGNAME" | sed -e "$xPATTERN" -e 's%\\-$%%' 2>/dev/null`"
+     PKGNAME_ONLY="$(echo -n "$PKGNAME" | sed -e "$xPATTERN" -e 's%\\-$%%' 2>/dev/null)"
     ;;
     tgz|txz)
      #slack ex: xvidtune-1.0.1-i486-1.tgz  printproto-1.0.4-noarch-1.tgz
-     PKGNAME="`echo -n "$pkg_name" | sed -e 's%\\-i[3456]86.*%%' -e 's%\\-noarch.*%%'`"
-     DB_version="`echo -n "$PKGNAME" | grep -o '\\-[0-9].*' | sed -e 's%^\\-%%'`"
-     xDB_version="`echo -n "$DB_version" | sed -e 's%\\-%\\\\-%g' -e 's%\\.%\\\\.%g'`"
+     PKGNAME="$(echo -n "$pkg_name" | sed -e 's%\\-i[3456]86.*%%' -e 's%\\-noarch.*%%')"
+     DB_version="$(echo -n "$PKGNAME" | grep -o '\\-[0-9].*' | sed -e 's%^\\-%%')"
+     xDB_version="$(echo -n "$DB_version" | sed -e 's%\\-%\\\\-%g' -e 's%\\.%\\\\.%g')"
      xPATTERN="s%${xDB_version}%%"
-     PKGNAME_ONLY="`echo -n "$PKGNAME" | sed -e "$xPATTERN" -e 's%\-$%%' 2>/dev/null`"
+     PKGNAME_ONLY="$(echo -n "$PKGNAME" | sed -e "$xPATTERN" -e 's%\-$%%' 2>/dev/null)"
     ;;
     tar.gz)
      #arch ex: xproto-7.0.14-1-i686.pkg.tar.gz  trapproto-3.4.3-1.pkg.tar.gz
-     PKGNAME="`echo -n "$pkg_name" | sed -e 's%\\-i[3456]86.*%%' -e 's%\\.pkg$%%' | rev | cut -f 2-9 -d '-' | rev`"
-     DB_version="`echo -n "$PKGNAME" | grep -o '\\-[0-9].*' | sed -e 's%^\\-%%'`"
-     xDB_version="`echo -n "$DB_version" | sed -e 's%\\-%\\\\-%g' -e 's%\\.%\\\\.%g'`"
+     PKGNAME="$(echo -n "$pkg_name" | sed -e 's%\\-i[3456]86.*%%' -e 's%\\.pkg$%%' | rev | cut -f 2-9 -d '-' | rev)"
+     DB_version="$(echo -n "$PKGNAME" | grep -o '\\-[0-9].*' | sed -e 's%^\\-%%')"
+     xDB_version="$(echo -n "$DB_version" | sed -e 's%\\-%\\\\-%g' -e 's%\\.%\\\\.%g')"
      xPATTERN="s%${xDB_version}%%"
-     PKGNAME_ONLY="`echo -n "$PKGNAME" | sed -e "$xPATTERN" -e 's%\\-$%%' 2>/dev/null`"
+     PKGNAME_ONLY="$(echo -n "$PKGNAME" | sed -e "$xPATTERN" -e 's%\\-$%%' 2>/dev/null)"
     ;;
     rpm) #110523
      #exs: hunspell-fr-3.4-1.1.el6.noarch.rpm
      PKGNAME="$pkg_name"
-     DB_version="`echo -n "$PKGNAME" | grep -o '\\-[0-9].*' | sed -e 's%^\-%%'`"
-     xDB_version="`echo -n "$DB_version" | sed -e 's%\\-%\\\\-%g' -e 's%\\.%\\\\.%g'`"
+     DB_version="$(echo -n "$PKGNAME" | grep -o '\\-[0-9].*' | sed -e 's%^\-%%')"
+     xDB_version="$(echo -n "$DB_version" | sed -e 's%\\-%\\\\-%g' -e 's%\\.%\\\\.%g')"
      xPATTERN="s%${xDB_version}%%"
-     PKGNAME_ONLY="`echo -n "$PKGNAME" | sed -e "$xPATTERN" -e 's%\\-$%%' 2>/dev/null`"
+     PKGNAME_ONLY="$(echo -n "$PKGNAME" | sed -e "$xPATTERN" -e 's%\\-$%%' 2>/dev/null)"
     ;;
   esac
-  [ "$PKGNAME_ONLY" != '' ] && echo $PKGNAME_ONLY || echo "$1"
+  [ "$PKGNAME_ONLY" != '' ] && echo "$PKGNAME_ONLY" || echo "$1"
 }
 
 
@@ -572,29 +599,28 @@ get_pkg_name_only(){              # return pkg name only from $1, with no versio
   local pkg_name=''
   local pkg_name_only=''
   local name_only=''
-  local pkg_ext=`get_pkg_ext "$1"`
+  local pkg_ext=$(get_pkg_ext "$1")
   local repo_of_pkg=''
-  local repo_pkg_with_ext=''
-  local repo_ext=$EX      # from $PKGRC
+  local repo_ext="$EX"      # from $PKGRC
 
   # check the repos
-  local pkg_name_only="`grep -m1 "|${1}|" ${HOME}/.packages/Packages-* 2>/dev/null | cut -f2 -d'|'`"
-  [ "$pkg_name_only" = '' ] && pkg_name_only="`grep -m1 "^${1}|" ${HOME}/.packages/Packages-* 2>/dev/null | cut -f2 -d'|' | head -1`"
-  [ "$pkg_name_only" = '' ] && pkg_name_only="`grep -m1 "|${1}.${pkg_ext}|" ${HOME}/.packages/Packages-* 2>/dev/null | cut -f2 -d'|' | head -1`"
+  local pkg_name_only="$(grep -m1 "|${1}|" ${HOME}/.packages/Packages-* 2>/dev/null | cut -f2 -d'|')"
+  [ "$pkg_name_only" = '' ] && pkg_name_only="$(grep -m1 "^${1}|" ${HOME}/.packages/Packages-* 2>/dev/null | cut -f2 -d'|' | head -1)"
+  [ "$pkg_name_only" = '' ] && pkg_name_only="$(grep -m1 "|${1}.${pkg_ext}|" ${HOME}/.packages/Packages-* 2>/dev/null | cut -f2 -d'|' | head -1)"
 
-  pkg_name_only=${pkg_name_only// */}
+  pkg_name_only="${pkg_name_only// */}"
 
   # if we found it, print it and exit
   if [ "$pkg_name_only" != '' ];then
-      echo ${pkg_name_only}
+      echo "${pkg_name_only}"
       return 0
   fi
 
   # if not, but we have an extension, try  get_pkg_name_only_from_ext()
   case $DISTRO_BINARY_COMPAT in ubuntu|trisquel|debian|devuan)
-    name_only=`get_pkg_name_only_from_ext "$(basename "${1}.${repo_ext}")"| head -1`
-    name_only=${name_only// */}
-    [ "$name_only" != '' -a "$name_only" != "$1" ] && echo $name_only && return 0
+    name_only=$(get_pkg_name_only_from_ext "$(basename "${1}.${repo_ext}")"| head -1)
+    name_only="${name_only// */}"
+    [ "$name_only" != '' ] && [ "$name_only" != "$1" ] && echo "$name_only" && return 0
     ;;
   esac
 
@@ -603,21 +629,21 @@ get_pkg_name_only(){              # return pkg name only from $1, with no versio
   # replace the dash before the version number with an @ symbol.
   # INFO: sed /-[^-][^+][^a-zA-Z][0-9.]*/ (hopefully?) replaces '-$VER' with '@'
   # not including when $VER starts with a number/letter
-  pkg_name_only="`echo "$(basename "${1}")" | sed -e 's/-[^-][^+][^a-zA-Z][0-9.]*/@/'`"
+  pkg_name_only="$(basename "${1/-[^-][^+][^a-zA-Z][0-9.]*/@}")"
 
   # do 'ioquake3+u20130504' => 'oquake3'
-  pkg_name_only="`echo "${pkg_name_only}" | sed -e 's/+[a-z]/@/'`"
+  pkg_name_only="${pkg_name_only/+[Aa-Zz]/@}"
 
   # note, we haven't cut away version numbers preceeded with underscores (_) yet
 
   # if the version number was preceeded by an underscore, the version
   # will still be in the $pkg_name_only - pkgname_2.3.4 - so cut it out
-  if [ "`echo "$pkg_name_only" | grep -o "_[0-9]\."`" != '' ];then
-    pkg_name_only="`echo "$pkg_name_only" | sed -e 's/_[^a-z][^A-Z][0-9.]*/@/'`"
+  if [ "$(echo "$pkg_name_only" | grep -o "_[0-9]\.")" != '' ];then
+    pkg_name_only="${pkg_name_only/_[^a-z][^A-Z][0-9.]*/@}"
 
   # maybe the underscore preceeds a version that starts with a letter
-  elif [ "`echo "$pkg_name_only" | grep -o "_[a-zA-Z][0-9]\."`" != '' ];then
-    pkg_name_only="`echo "$pkg_name_only" | sed -e 's/_[a-zA-Z][0-9.]*/@/'`"
+  elif [ "$(echo "$pkg_name_only" | grep -o "_[a-zA-Z][0-9]\.")" != '' ];then
+    pkg_name_only="${pkg_name_only/_[a-zA-Z][0-9.]*/@}"
   fi
 
   # now cut away everything after the @, that will leave only the package name
@@ -625,35 +651,36 @@ get_pkg_name_only(){              # return pkg name only from $1, with no versio
   pkg_name_only="$pkg_name_only1"
 
   # we might still have foo_bar_v1.2.3, so lets chop off * after the last _
-  if [ "`echo "$pkg_name_only" | grep -o "_[a-zA-Z][0-9]\."`" != '' ];then
+  if [ "$(echo "$pkg_name_only" | grep -o "_[a-zA-Z][0-9]\.")" != '' ];then
     pkg_name_only="${pkg_name_only/_[a-zA-Z][0-9]*/}"
   fi
 
   # another chop, we might have foo_bar_vv1.2.3, so lets chop off
   # everything after the last underscore, if we still have version numbers
-  if [ "`echo "$pkg_name_only" | grep -o "_[a-zA-Z][a-zA-Z][0-9]\."`" != '' ];then
+  if [ "$(echo "$pkg_name_only" | grep -o "_[a-zA-Z][a-zA-Z][0-9]\.")" != '' ];then
     pkg_name_only="${pkg_name_only/_[a-zA-Z][a-zA-Z][0-9]*/}"
   fi
 
   # we might still have foo_bar_vvv1.2.3, so lets chop off
   # everything after the last underscore, if we still have version numbers
-  if [ "`echo "$pkg_name_only" | grep -o "_[a-zA-Z*][0-9]\."`" != '' ];then
+  if [ "$(echo "$pkg_name_only" | grep -o "_[a-zA-Z*][0-9]\.")" != '' ];then
     pkg_name_only="${pkg_name_only/_[a-zA-Z*][0-9]*/}"
   fi
 
   # chop again, we might have abc_xwy-zzz1.2.3-blah-etc, so lets chop off
   # everything after the last dash-before-number
-  if [ "`echo "$pkg_name_only" | grep -o "\-[a-zA-Z*]*[0-9]\."`" != '' ];then
+  if [ "$(echo "$pkg_name_only" | grep -o "\-[a-zA-Z*]*[0-9]\.")" != '' ];then
     pkg_name_only="${pkg_name_only/-[a-zA-Z*]*[0-9]*/}"
   fi
 
   # another fix, if we still have PKGNAME-1.2, remove the '-1.2'
-  if [ "`echo "$pkg_name_only" | grep -o "\-[0-9]"`" != '' ];then
+  if [ "$(echo "$pkg_name_only" | grep -o "\-[0-9]")" != '' ];then
     pkg_name_only="${pkg_name_only/-[0-9]*/}"
   fi
 
   # the sed bit changes 'liblzma5+20120614' to 'liblzma5'
-  [ "$pkg_name_only" != '' ] && echo $pkg_name_only | sed -e 's/\+[a-z0-9].*//g' || return 1
+  # shellcheck disable=SC2001
+  [ "$pkg_name_only" != '' ] && echo "$pkg_name_only" | sed -e 's/\+[a-z0-9].*//g' || return 1
 }
 
 
@@ -666,34 +693,39 @@ get_pkg_name(){                   # return full pkg name (with version) from $1 
   local pkg_name=''
   local full_name=''
   local supported_repo_files=''
-  local repo_contents=''
 
   # get the extension of the given package name, if any
-  local pkg_ext=`get_pkg_ext "$1"`
+  local pkg_ext=$(get_pkg_ext "$1")
   # get the name without path and extension
   local pkg_name="$(basename "$1" .$pkg_ext)"
 
   # get the repos files in the correct (fall back) order, then add file paths
-  supported_repo_files="`repo_file_list | sed -e "s#^#$HOME/.packages/#g"`"
+  supported_repo_files="$(repo_file_list | sed -e "s#^#$HOME/.packages/#g")"
 
   # get the relevant repo contents (fields 1,2,8) from all repos,
   # then add pipes to line start/end for easier parsing later, then do
   # a basic search, for $pkg* (we'll refine it later), to avoid 'Argument list too long'..
-  cut -f1,2,8 $HOME/.packages/user-installed-packages $HOME/.packages/woof-installed-packages $supported_repo_files | sed -e "s/^/|/g" -e "s/$/|/g" 2>/dev/null | grep -i "|$pkg_name" > ${TMPDIR}/repo_contents
+  cut -f1,2,8 $supported_repo_files $HOME/.packages/user-installed-packages $HOME/.packages/woof-installed-packages \
+    | sed \
+      -e "s/^/|/g" \
+      -e "s/$/|/g" 2>/dev/null \
+    | grep -i "|$pkg_name" > ${TMPDIR}/repo_contents
+
 
   # get fields 1,2 and 8 (the 3 name fields) from all supported repo files, then
   # add '|' to start and end of lines, then find exact match of $pkg_name..
   # if no exact match, look for $pkg_name-*, then $pkg_name_*
   if [ -f ${TMPDIR}/repo_contents ];then
-    full_name=`cat ${TMPDIR}/repo_contents 2>/dev/null| grep -m1 "|${pkg_name}|"` \
-      || full_name=`cat ${TMPDIR}/repo_contents 2>/dev/null|grep -m1 "|${pkg_name//-*/}|"` \
-      || full_name=`cat ${TMPDIR}/repo_contents 2>/dev/null|grep -m1 "|${pkg_name//_*/}|"` \
-      || full_name=`cat ${TMPDIR}/repo_contents 2>/dev/null|grep -m1 "|${pkg_name}-"` \
-      || full_name=`cat ${TMPDIR}/repo_contents 2>/dev/null|grep -m1 "|${pkg_name}_"` \
-      || full_name=`cat ${TMPDIR}/repo_contents 2>/dev/null|grep -m1 "|${pkg_name}"` \
-      || full_name=`cat ${TMPDIR}/repo_contents 2>/dev/null|grep -m1 "^${pkg_name}|"` \
-      || full_name=`cat ${TMPDIR}/repo_contents 2>/dev/null|grep -m1 "^${pkg_name}-"` \
-      || full_name=`cat ${TMPDIR}/repo_contents 2>/dev/null|grep -m1 "^${pkg_name}_"`
+
+    full_name=$(  grep -m1 "|${pkg_name}|"      "${TMPDIR}/repo_contents")  || \
+      full_name=$(grep -m1 "|${pkg_name//-*/}|" "${TMPDIR}/repo_contents")  || \
+      full_name=$(grep -m1 "|${pkg_name//_*/}|" "${TMPDIR}/repo_contents")  || \
+      full_name=$(grep -m1 "|${pkg_name}-"      "${TMPDIR}/repo_contents")  || \
+      full_name=$(grep -m1 "|${pkg_name}_"      "${TMPDIR}/repo_contents")  || \
+      full_name=$(grep -m1 "|${pkg_name}"       "${TMPDIR}/repo_contents")  || \
+      full_name=$(grep -m1 "^${pkg_name}|"      "${TMPDIR}/repo_contents")  || \
+      full_name=$(grep -m1 "^${pkg_name}-"      "${TMPDIR}/repo_contents")  || \
+      full_name=$(grep -m1 "^${pkg_name}_"      "${TMPDIR}/repo_contents")
 
       full_name="${full_name//_amd64/}"
       full_name="${full_name//_arm64/}"
@@ -706,7 +738,7 @@ get_pkg_name(){                   # return full pkg name (with version) from $1 
   fi
 
   # if we found pkg in repo, keep only the package name ('|pkg-123|pkg|blah|' -> 'pkg-123')
-  [ "$full_name" != '' ] && full_name=`echo $full_name| cut -f2 -d '|' | tr -d '|'` || full_name=$pkg_name
+  [ "$full_name" != '' ] && full_name=$(echo $full_name| cut -f2 -d '|' | tr -d '|') || full_name="$pkg_name"
 
   # if we have a package name, return it here and leave the func
   [ "$full_name" != '' ] && echo $full_name && return 0
@@ -722,61 +754,90 @@ get_pkg_name(){                   # return full pkg name (with version) from $1 
 
   # if no pkg found in repos, we cant translate/lookup its longer name,
   # so just return what we got, without path, without pkg extension
-  [ "$full_name" = '' ] && echo "`basename "$pkg_name" .$pkg_ext`"
+  [ "$full_name" = '' ] && basename "$pkg_name" .$pkg_ext
+}
+
+
+get_pkg_filename(){              # return filename of $1, if its a local file or repo package FUNCLIST
+  # exit if no valid options
+  [ ! "$1" ] || [ "$1" = "-" ] && exit 1
+
+  if [ -f "$1" ];then
+    basename "$1"
+    return 0
+  fi
+
+  # strip away extension and path
+  local PKGNAME="$(basename "$1" .$EX)"
+  local PKGNAME=$(get_pkg_name "$PKGNAME")
+  local PKGNAME_ONLY=$(get_pkg_name_only "$PKGNAME")
+
+  # check repos in fallback order
+  all_supported_repofiles=$(repo_file_list | sed "s#^#$HOME/.packages/#" | tr '\n' ' ')
+
+  local pkgname
+
+  for repofile in $HOME/.packages/${REPOFILE} ~/.packages/*-installed-packages $all_supported_repofiles
+  do
+    pkgname="$(grep -m1 "^$PKGNAME|" "$repofile" | cut -f8 -d'|')"
+    [ ! -z "$pkgname" ] && break
+    pkgname="$(grep -m1 "|$PKGNAME_ONLY|" "$repofile" | cut -f8 -d'|')"
+    [ ! -z "$pkgname" ] && break
+  done
+  [ ! -z "$pkgname" ] && echo "$pkgname"
 }
 
 
 is_blacklisted_pkg(){             # return true if PKGNAME ($1) is blacklisted FUNCLIST
   # exit if no valid options
-  [ ! "$1" -o "$1" = "-" ] && exit 1
+  [ ! "$1" ] || [ "$1" = "-" ] && exit 1
 
   # if we find an exact match of PKGNAME_ONLY in $PKG_BLACKLIST
-  if [ "`echo "$PKG_BLACKLIST" | grep -E "^$(get_pkg_name_only "$1")\$"`" != '' ];then
+  if [ "$(echo "$PKG_BLACKLIST" | grep -E "^$(get_pkg_name_only "$1")\$")" != '' ];then
     echo true
-  else
-    echo false
-    return 1
+    return 0
   fi
+  echo false
+  return 1
 }
 
 
 is_installed_pkg(){               # return true if PKGNAME ($1) is installed, else false FUNCLIST
 
   # exit if no valid options
-  [ ! "$1" -o "$1" = "-" ] && print_usage pkg-installed && exit 1
+  [ ! "$1" ] || [ "$1" = "-" ] && print_usage pkg-installed && exit 1
 
   local EX=''
   local PKGNAME=''
   local PKGNAME_ONLY=''
   local check=''
+  local repo_files="$HOME/.packages/woof-installed-packages $HOME/.packages/user-installed-packages"
 
   # get pkg extension
-  EX=`get_pkg_ext "$1"`
+  EX=$(get_pkg_ext "$1")
 
   # strip away extension and path
   PKGNAME="$(basename "$1" .$EX)"
-  PKGNAME=`get_pkg_name "$PKGNAME"`
+  PKGNAME=$(get_pkg_name "$PKGNAME")
 
   # we cant rely on the strings the user passes us, so...
 
   # get the package name without version
-  PKGNAME_ONLY=`get_pkg_name_only "$PKGNAME"`
+  PKGNAME_ONLY=$(get_pkg_name_only "$PKGNAME")
 
   # exit if no valid package name
-  [ "$PKGNAME" = '' -o "$PKGNAME_ONLY" = '' ] && print_usage pkg-installed && exit 1
-
-  # check the $HOME/.packages/*.files
-  check="`find ${HOME}/.packages/ -name "$PKGNAME.files"`"
-  [ "$check" = '' ] && check="`find ${HOME}/.packages/ -name "${PKGNAME}_*.files"`"
-  [ "$check" = '' ] && check="`find ${HOME}/.packages/ -name "${PKGNAME}-*.files"`"
-  [ "$check" = '' ] && check="`find ${HOME}/.packages/ -name "${PKGNAME}*.files"`"
+  if [ "$PKGNAME" = '' ] || [ "$PKGNAME_ONLY" = '' ];then
+    print_usage pkg-installed && exit 1
+  fi
 
   # slow but reliable & simple: separately check fields 1,2,8 of the various files listing installed pkgs
-  [ "$check" = '' ] && check="`cut -f1 -d'|' ${HOME}/.packages/*-installed-packages 2>/dev/null| grep -m1 "^$PKGNAME\$"`"
-  [ "$check" = '' ] && check="`cut -f1,2 -d'|' ${HOME}/.packages/*-installed-packages 2>/dev/null| grep -m1 "^$PKGNAME|" | grep -m1 "|$PKGNAME_ONLY\$"`"
-  [ "$check" = '' ] && check="`cut -f8 -d'|' ${HOME}/.packages/*-installed-packages 2>/dev/null| grep -m1 "^$PKGNAME"`"
-  [ "$check" = '' ] && check="`HIDE_BUILTINS=false list_installed_pkgs | grep -m1 ^"$PKGNAME"`"
-
+  [ "$check" = '' ] && check="$(cut -f1,2 -d'|' $repo_files | grep -m1 "^$PKGNAME|")"
+  [ "$check" = '' ] && check="$(cut -f1,2 -d'|' $repo_files | grep -m1 "^$PKGNAME" | grep -m1 "|$PKGNAME_ONLY\$")"
+  [ "$check" = '' ] && check="$(cut -f8   -d'|' $repo_files | grep -m1 "^$(get_pkg_filename ${PKGNAME//.$EX/.files})")"
+  # check the $HOME/.packages/*.files
+  [ "$check" = '' ] && check="$(find ${HOME}/.packages/ -name "$(get_pkg_filename ${PKGNAME//.$EX/.files})")"
+  [ "$check" = '' ] && check="$(find ${HOME}/.packages/ -name "$PKGNAME.files")"
+   
   # if any checks above returned a result, $check will not be empty (ash didn't like grep -q, not sure why?)
   [ "$check" != '' ] && echo true || echo false
 }
@@ -794,20 +855,20 @@ is_builtin_pkg (){                # return true if $1 is a builtin pkg, else fal
   local pkg_builtin=''
   local pkg_name_only=''
 
-  pkg_builtin="`cut -f1,2,8 -d '|' ${HOME}/.packages/woof-installed-packages 2>/dev/null\
+  pkg_builtin="$(cut -f1,2,8 -d '|' ${HOME}/.packages/woof-installed-packages 2>/dev/null \
     | sed -e 's@^@|@' -e 's@$@|@' \
-    | grep -m1 "|$1|"`"
+    | grep -m1 "|$1|")"
 
   # try again.. if user gave only partial name (geany-1.27), the above would fail
   if [ "$pkg_builtin" = '' ];then
-    pkg_name_only=`get_pkg_name_only "$1"`
+    pkg_name_only=$(get_pkg_name_only "$1")
 
     # so search for pkg_name* AND pkg_name_only (exact match, should be in field 2)
     if [ "$pkg_name_only" != '' ];then
-      pkg_builtin="`cut -f1,2,8 -d '|' ${HOME}/.packages/woof-installed-packages 2>/dev/null\
+      pkg_builtin="$(cut -f1,2,8 -d '|' ${HOME}/.packages/woof-installed-packages 2>/dev/null \
         | sed -e 's@^@|@' -e 's@$@|@' \
         | grep "|$1" \
-        | grep -m1 "|$pkg_name_only|"`"
+        | grep -m1 "|$pkg_name_only|")"
     fi
   fi
 
@@ -828,20 +889,20 @@ is_devx_pkg (){                   # return true if $1 is a pkg in the devx, else
   local devx_pkg=''
   local pkg_name_only=''
 
-  devx_pkg="`cut -f1,2,8 -d '|' ${HOME}/.packages/devx-only-installed-packages 2>/dev/null\
+  devx_pkg="$(cut -f1,2,8 -d '|' ${HOME}/.packages/devx-only-installed-packages 2>/dev/null\
     | sed -e 's@^@|@' -e 's@$@|@' \
-    | grep -m1 "|$1|"`"
+    | grep -m1 "|$1|")"
 
   # try again.. if user gave only partial name (geany-1.27), the above would fail
   if [ "$devx_pkg" = '' ];then
-    pkg_name_only=`get_pkg_name_only "$1"`
+    pkg_name_only=$(get_pkg_name_only "$1")
 
     # so search for pkg_name* AND |pkg_name_only| (exact match, should be in field 2)
     if [ "$pkg_name_only" != '' ];then
-      devx_pkg="`cut -f1,2,8 -d '|' ${HOME}/.packages/devx-only-installed-packages 2>/dev/null\
+      devx_pkg="$(cut -f1,2,8 -d '|' ${HOME}/.packages/devx-only-installed-packages 2>/dev/null\
         | sed -e 's@^@|@' -e 's@$@|@' \
         | grep "|$1" \
-        | grep -m1 "|$pkg_name_only|"`"
+        | grep -m1 "|$pkg_name_only|")"
     fi
   fi
 
@@ -862,20 +923,20 @@ is_usr_pkg (){                    # return true if $1 is a user installed pkg, e
   local usr_pkg=''
   local pkg_name_only=''
 
-  usr_pkg="`cut -f1,2,8 -d '|' ${HOME}/.packages/user-installed-packages 2>/dev/null\
+  usr_pkg="$(cut -f1,2,8 -d '|' ${HOME}/.packages/user-installed-packages 2>/dev/null \
     | sed -e 's@^@|@' -e 's@$@|@' \
-    | grep -m1 "|$1|"`"
+    | grep -m1 "|$1|")"
 
   # try again.. if user gave only partial name (geany-1.27), the above would fail
   if [ "$usr_pkg" = '' ];then
-    pkg_name_only=`get_pkg_name_only "$1"`
+    pkg_name_only=$(get_pkg_name_only "$1")
 
     # so search for pkg_name* AND |pkg_name_only| (exact match, should be in field 2)
     if [ "$pkg_name_only" != '' ];then
-      usr_pkg="`cut -f1,2,8 -d '|' ${HOME}/.packages/user-installed-packages 2>/dev/null\
+      usr_pkg="$(cut -f1,2,8 -d '|' ${HOME}/.packages/user-installed-packages 2>/dev/null \
         | sed -e 's@^@|@' -e 's@$@|@' \
         | grep "|$1" \
-        | grep -m1 "|$pkg_name_only|"`"
+        | grep -m1 "|$pkg_name_only|")"
     fi
   fi
 
@@ -898,29 +959,29 @@ is_repo_pkg (){                   # return true if $1 is a pkg in a supported re
   local all_supported_repofiles
 
   # all repo files, full paths
-  all_supported_repofiles=`repo_file_list | sed "s#^#$HOME/.packages/#" | tr '\n' ' '`
+  all_supported_repofiles=$(repo_file_list | sed "s#^#$HOME/.packages/#" | tr '\n' ' ')
 
   # search all repo files for the $1
-  repo_pkg="`cut -f1,2,8 -d '|' $all_supported_repofiles 2>/dev/null\
+  repo_pkg="$(cut -f1,2,8 -d '|' $all_supported_repofiles 2>/dev/null\
     | sed -e 's/ //g' -e 's@^@|@' -e 's@$@|@' \
-    | grep -m1 "|${1}|"`"
+    | grep -m1 "|${1}|")"
 
   # search all repo files for the $1*
   [ "$repo_pkg" = '' ] \
-    && repo_pkg="`cut -f1,2,8 -d '|' $all_supported_repofiles 2>/dev/null\
+    && repo_pkg="$(cut -f1,2,8 -d '|' $all_supported_repofiles 2>/dev/null\
     | sed -e 's/ //g' -e 's@^@|@' -e 's@$@|@' \
-    | grep -m1 "|${1}-\?_\?[0-9.a-zA-Z]*|"`"
+    | grep -m1 "|${1}-\?_\?[0-9.a-zA-Z]*|")"
 
   # try again.. if user gave only partial name (geany-1.27), the above would fail
   if [ "$repo_pkg" = '' ];then
-    pkg_name_only=`get_pkg_name_only "$1"`
+    pkg_name_only=$(get_pkg_name_only "$1")
 
     # so search for pkg_name* AND |pkg_name_only| (exact match, should be in field 2)
     if [ "$pkg_name_only" != '' ];then
-      repo_pkg="`cut -f1,2,8 -d '|' $all_supported_repofiles 2>/dev/null\
+      repo_pkg="$(cut -f1,2,8 -d '|' $all_supported_repofiles 2>/dev/null\
         | sed -e 's@^@|@' -e 's@$@|@' \
         | grep "|$1" \
-        | grep -m1 "|$pkg_name_only|"`"
+        | grep -m1 "|$pkg_name_only|")"
     fi
   fi
 
@@ -935,12 +996,15 @@ is_current_repo_pkg(){            # takes $PKGNAME ($1), returns true or false F
   [ ! "$1"  ] && exit 1
 
   # get current repo ($REPOFILE)
-  . ${PKGRC}
+  . "${PKGRC}"
 
   local pkg_in_repo
 
   # check if given pkg ($1) is in the current repo
-  pkg_in_repo="`LANG=C cut -f1,2,7,8 -d'|' ${HOME}/.packages/$REPOFILE 2>/dev/null | sed -e "s/^/|/" -e "s/$/|/" | grep -m1 "|${1}|"`"
+  pkg_in_repo="$(LANG=C cut -f1,2,7,8 -d'|' ${HOME}/.packages/$REPOFILE 2>/dev/null \
+    | sed -e "s/^/|/" \
+          -e "s/$/|/" \
+    | grep -m1 "|$1|")"
 
   # print msg
   [ "$pkg_in_repo" != '' ] && echo true || echo false
@@ -952,12 +1016,10 @@ is_local_pkg(){                   # returns true if $1 is local package file FUN
   # exit if no valid input
   [ ! "$1"  ] && exit 1
 
-  . ${PKGRC}
+  . "${PKGRC}"
 
   # if $1 is a local file with a supported package extension
   # then we return true, else, we return false
-
-  local is_file=''
   local is_local_pkg=false
 
   # first, check we have a local file
@@ -965,19 +1027,19 @@ is_local_pkg(){                   # returns true if $1 is local package file FUN
 
     # file *probably* has an extension, lets try to get it..
     # the func get_pkg_ext() will return empty if not a valid package extension
-    file_ext=`get_pkg_ext "$1"`
+    file_ext=$(get_pkg_ext "$1")
 
     # if not empty, it must be a local file, with valid pkg ext (a local pkg)
     [ "$file_ext" != '' ] && is_local_pkg=true
 
   elif [ -f "$CURDIR/$1" ];then
 
-    file_ext=`get_pkg_ext "$CURDIR/$1"`
+    file_ext=$(get_pkg_ext "$CURDIR/$1")
     [ "$file_ext" != '' ] && is_local_pkg=true
 
   elif [ -f "$WORKDIR/$1" ];then
 
-    file_ext=`get_pkg_ext "$CURDIR/$1"`
+    file_ext=$(get_pkg_ext "$CURDIR/$1")
     [ "$file_ext" != '' ] && is_local_pkg=true
 
   fi
@@ -985,7 +1047,6 @@ is_local_pkg(){                   # returns true if $1 is local package file FUN
   # print output
   echo $is_local_pkg
 }
-
 
 
 # RC file funcs
@@ -1009,7 +1070,7 @@ set_workdir(){                    # set new WORKDIR in rc file location FUNCLIST
   # dir was created, so lets copy our pkgs in there
   list_downloaded_pkgs | while read pkg_file
   do
-    cp -v "$WORKDIR/$pkg_name" "$1/"
+    cp -v "$WORKDIR/$pkg_file" "$1/"
   done
 
   # if copying everything to new dir failed
@@ -1030,7 +1091,7 @@ set_workdir(){                    # set new WORKDIR in rc file location FUNCLIST
 set_pkg_scope(){                  # one|all set search for pkgs in current repo or all FUNCLIST
 
   # get old values, any we dont set here are not overwritten
-  . ${PKGRC}
+  . "${PKGRC}"
 
   [ "$1" != "" ] && PKGSCOPE="$1" || PKGSCOPE="$PKGSCOPE"
 
@@ -1088,14 +1149,17 @@ set_dep_scope(){                  # all|one set search for deps in current repo 
 
 
 set_recursive_deps(){             # yes|no search for deps of deps or not FUNCLIST
-  [ "`echo $1 | grep -E "^yes\$|^no\$"`" = "" ] && print_usage recursive-dep-check && exit 1
+  [ "$(echo $1 | grep -E "^yes\$|^no\$")" = "" ] && print_usage recursive-dep-check && exit 1
 
   # get old values, any we dont set here are not overwritten
-  . ${PKGRC}
+  . "${PKGRC}"
 
   # make sure we have a valid value
   RDCHECK="$1"
-  [ "$RDCHECK" = "yes" -o "$RDCHECK" = "no" ] || RDCHECK=no
+  if [ "$RDCHECK" != "yes" ] && [ "$RDCHECK" != "no" ]
+  then
+    RDCHECK=no
+  fi
 
   set_config
 
@@ -1109,14 +1173,17 @@ set_recursive_deps(){             # yes|no search for deps of deps or not FUNCLI
 
 
 set_bleeding_edge(){              # yes|no get latest pkgs, ignore fall backs FUNCLIST
-  [ "`echo $1 | grep -E "^yes\$|^no\$"`" = "" ] && echo usage bleeding-edge && exit 1
+  [ "$(echo $1 | grep -E "^yes\$|^no\$")" = "" ] && echo usage bleeding-edge && exit 1
 
   #get old values, any we dont set here are not overwritten
-  . ${PKGRC}
+  . "${PKGRC}"
 
   # make sure we have a valid value
   BLEDGE="$1"
-  [ "$BLEDGE" = "yes" -o "$BLEDGE" = "no" ] || BLEDGE=no
+  if [ "$BLEDGE" != "yes" ] && [ "$BLEDGE" != "no" ]
+  then
+    BLEDGE=no
+  fi
 
   set_config
 
@@ -1130,14 +1197,17 @@ set_bleeding_edge(){              # yes|no get latest pkgs, ignore fall backs FU
 
 
 set_autoclean(){                  # yes|no auto delete installed packages from WORKDIR FUNCLIST
-  [ "`echo $1 | grep -E "^yes\$|^no\$"`" = "" ] && print_usage autoclean && exit 1
+  [ "$(echo $1 | grep -E "^yes\$|^no\$")" = "" ] && print_usage autoclean && exit 1
 
   #get old values, any we dont set here are not overwritten
   . ${PKGRC}
 
   # make sure we have a valid value
   AUTOCLEAN="$1"
-  [ "$AUTOCLEAN" = "yes" -o "$AUTOCLEAN" = "no" ] || AUTOCLEAN=no
+  if [ "$AUTOCLEAN" != "yes" ] && [ "$AUTOCLEAN" != "no" ]
+  then
+    AUTOCLEAN=no
+  fi
 
   set_config
 
@@ -1179,13 +1249,13 @@ set_config(){                     # update all options in config file FUNCLIST
 
 
 show_config(){                    # show config settings from ~/.pkg/pkgrc FUNCLIST
-  . ${PKGRC}
+  . "${PKGRC}"
 
   # set default values
   PKGSCOPETXT="Search for packages in all repos."
   DEPSCOPETXT="Search for dependencies in all repos."
   FALLBACKTXT="Accessing other repos in this order:"
-  FALLBACKTXT="$FALLBACKTXT\n`repo_list | grep -v "^$REPONAME" | tr '\n' ' ' | sed -e "s/ /, /g" -e "s/, $//" | fold -w 54 -s`"
+  FALLBACKTXT="$FALLBACKTXT\n$(repo_list | grep -v "^$REPONAME" | tr '\n' ' ' | sed -e "s/ /, /g" -e "s/, $//" | fold -w 54 -s)"
   RDCHECKTXT="Recursive dependency search is NOT enabled."
 
   # update with values from PKGRC file
@@ -1214,11 +1284,12 @@ show_config(){                    # show config settings from ~/.pkg/pkgrc FUNCL
   echo "Repo details:"
   echo "- Current Repo: $REPONAME"
   echo "- Package type: $EX"
-  echo "- Packages:     `cat ${HOME}/.packages/${REPOFILE} | wc -l`"
-  echo "- Mirror 1:     `echo $REPOURL1 | cut -f1-3 -d'/' `"
-  [ "$REPOURL2" != "" ] && echo "- Mirror 2:     `echo $REPOURL2 | cut -f1-3 -d'/' `"
-  [ "$REPOURL3" != "" ] && echo "- Mirror 3:     `echo $REPOURL3 | cut -f1-3 -d'/' `"
-  [ "$REPOURL4" != "" ] && echo "- Mirror 4:     `echo $REPOURL4 | cut -f1-3 -d'/' `"
+  # shellcheck disable=SC2002
+  echo "- Packages:    $(cat ${HOME}/.packages/${REPOFILE} | wc -l)"
+  echo "- Mirror 1:     $(echo "$REPOURL1" | cut -f1-3 -d'/')"
+  [ "$REPOURL2" != "" ] && echo "- Mirror 2:     $(echo "$REPOURL2" | cut -f1-3 -d'/' )"
+  [ "$REPOURL3" != "" ] && echo "- Mirror 3:     $(echo "$REPOURL3" | cut -f1-3 -d'/' )"
+  [ "$REPOURL4" != "" ] && echo "- Mirror 4:     $(echo "$REPOURL4" | cut -f1-3 -d'/' )"
   echo
   echo -e "$FALLBACKTXT"
 }
@@ -1227,12 +1298,15 @@ show_config(){                    # show config settings from ~/.pkg/pkgrc FUNCL
 # repo and source funcs
 
 get_repo_info(){                  # return details of given repo name ($1) FUNCLIST
-  [ ! "$1" -o "$1" = "-" ] && print_usage repo-info && exit 1
+  if [ ! "$1" ] || [ "$1" = "-" ];then
+    print_usage repo-info
+    exit 1
+  fi
 
-  REPOLINE="`list_all_sources $1 | sort -u`" #170214 always get latest info, not info from rcfile
+  REPOLINE="$(list_all_sources "$1" | sort -u)" #170214 always get latest info, not info from rcfile
 
   # on first run, this might be needed to set the repo correctly
-  [ "$REPOLINE" = '' ] && REPOLINE="`list_all_sources noarch`"
+  [ "$REPOLINE" = '' ] && REPOLINE="$(list_all_sources noarch)"
   #               1      2     3       4        5       6         7          8
   IFS="|" read REPONAME EX REPOFILE REPOURL1 REPOURL2 REPOURL3 REPOURL4 REPOFALLBACKS \
 	ETC <<EOF
@@ -1244,10 +1318,10 @@ EOF
 set_current_repo(){               # set the current repo to use, give repo name as $1 FUNCLIST
 
   # print usage if no valid options
-  [ ! "$1" -o "$1" = "-" -o "$1" = "-h" -o "$1" = "--help" ] && print_usage repo && exit 1
+  [ ! "$1" ] || [ "$1" = "-" ] || [ "$1" = "-h" ] || [ "$1" = "--help" ] && print_usage repo && exit 1
 
   # get repo details from rc file
-  . ${PKGRC}
+  . "${PKGRC}"
 
   # remove the default mirror tmp file, we're changing repo and mirrors
   rm $TMPDIR/CURREPOURL 2>/dev/null
@@ -1261,8 +1335,8 @@ set_current_repo(){               # set the current repo to use, give repo name 
   [ "$BLEDGE" = "" ]   && BLEDGE="$BLEDGE"
 
   # if nothing was found in rcfile, we need to set to default
-  [ "`echo $PKGSCOPE | grep -E "^one\$|^all\$"`" = "" ] && PKGSCOPE="one"
-  [ "`echo $DEPSCOPE | grep -E "^one\$|^all\$"`" = "" ] && DEPSCOPE="one"
+  [ "$(echo $PKGSCOPE | grep -E "^one\$|^all\$")" = "" ] && PKGSCOPE="one"
+  [ "$(echo $DEPSCOPE | grep -E "^one\$|^all\$")" = "" ] && DEPSCOPE="one"
   [ "$BLEDGE" = "" ] && BLEDGE="no"
 
   # check if $1 is valid repo
@@ -1286,19 +1360,19 @@ repo_list(){                      # list names of all avail repos [optionally ma
   # so Pkg can 'fall back' to other repos in that order
 
   # get current config
-  . ${PKGRC}
+  . "${PKGRC}"
 
   # set vars for this func
   local list=''
   local repo_file=''
-  local repo_names=`cut -f1 -d'|' ${HOME}/.pkg/sources`
-  local current_fallback_list=`grep "^$REPONAME|" ${HOME}/.pkg/sources | cut -f8 -d'|' | grep -v "^\$"`
+  local repo_names=$(cut -f1 -d'|' ${HOME}/.pkg/sources)
+  local current_fallback_list=$(grep "^$REPONAME|" ${HOME}/.pkg/sources | cut -f8 -d'|' | grep -v "^\$")
 
   # get current repo fallback list order.. note if repo not listed in fallback list, it will be appended after
   for line in $current_fallback_list
   do
     # get the repo file
-    repo_file="`grep "^$line|" ${HOME}/.pkg/sources | cut -f3 -d'|'`"
+    repo_file="$(grep "^$line|" ${HOME}/.pkg/sources | cut -f3 -d'|')"
     # add it to the list
     [ "$repo_file" != "" ] && list="$list$line "
   done
@@ -1307,11 +1381,14 @@ repo_list(){                      # list names of all avail repos [optionally ma
   for repo_name in $repo_names
   do
     #if not blank, not already in the repo list and not the current repo ($REPONAME from rc file) then add to list
-    [ "$repo_name" != "" -a "`echo "$list" | grep "$repo_name "`" = ""  -a "$repo_name" != "$REPONAME" ] && list="$list$repo_name "
+    [ "$repo_name" != "" ] \
+      && [ "$(echo "$list" | grep -m1 "$repo_name ")" = ""  ] \
+      && [ "$repo_name" != "$REPONAME" ] \
+      && list="${list}${repo_name} "
   done
 
   # list the current repo first
-  echo $REPONAME
+  echo "$REPONAME"
   # then the other repos
   echo "$list" | tr ' ' '\n' | grep -v "^\$"
 }
@@ -1323,19 +1400,19 @@ repo_file_list(){                 # list available repo files, $1 optional FUNCL
   # so Pkg can 'fall back' to other repos in that order
 
   # get current config
-  . ${PKGRC}
+  . "${PKGRC}"
 
   # set vars for this func
   local list=''
   local repo_file=''
-  local repo_files=`cut -f3 -d'|' ${HOME}/.pkg/sources`
-  local current_fallback_list=`grep "^$REPONAME|" ${HOME}/.pkg/sources | cut -f8 -d'|' | grep -v "^\$"`
+  local repo_files=$(cut -f3 -d'|' ${HOME}/.pkg/sources)
+  local current_fallback_list=$(grep "^$REPONAME|" ${HOME}/.pkg/sources | cut -f8 -d'|' | grep -v "^\$")
 
   # get current repo fallback list order.. note if repo not listed in fallback list, it will be appended after
   for line in $current_fallback_list
   do
     # get the repo file
-    repo_file="`grep "^$line|" ${HOME}/.pkg/sources | cut -f3 -d'|'`"
+    repo_file="$(grep "^$line|" ${HOME}/.pkg/sources | cut -f3 -d'|')"
     # add it to the list
     [ "$repo_file" != "" ] && list="$list$repo_file "
   done
@@ -1344,11 +1421,14 @@ repo_file_list(){                 # list available repo files, $1 optional FUNCL
   for repo_file in $repo_files
   do
     #if not blank, not already in the repo list and not the current repo ($REPONAME from rc file) then add to list
-    [ "$repo_file" != "" -a "`echo "$list" | grep "$repo_file "`" = ""  -a "$repo_file" != "$REPOFILE" ] && list="$list$repo_file "
+    [ "$repo_file" != "" ] \
+      && [ "$(echo "$list" | grep "$repo_file ")" = ""  ] \
+      && [ "$repo_file" != "$REPOFILE" ] \
+      && list="$list$repo_file "
   done
 
   # list the current repo first
-  echo $REPOFILE
+  echo "$REPOFILE"
   # then the other repos
   echo "$list" | tr ' ' '\n' | grep -v "^\$"
 }
@@ -1380,11 +1460,13 @@ dir2repo(){                       # create a native-Puppy repo from a dir of pac
   echo "Creating repo from contents of: $repo_dir"
   echo
 
+  local list
+  list="$(find "$repo_dir" -maxdepth 5 -type f)"
   # exit if we encounter multiple file extensions
-  for file in $(find "$repo_dir" -maxdepth 5 -type f)
+  for file in $list
   do
     filename=$(basename $file)
-    fileext="$(get_pkg_ext $filename)"
+    fileext="$(get_pkg_ext "$filename")"
     if [ "$fileext" != "$prevext" ] && [ "$prevext" != "" ];then
       echo "All packages must have the same extension."
       echo "Extensions '$fileext' and '$prevext' don't match."
@@ -1412,12 +1494,11 @@ dir2repo(){                       # create a native-Puppy repo from a dir of pac
     # get the package info
     filename=$(basename $file)
     fileext="$(get_pkg_ext $filename)"
-    filepath="$(realpath $(dirname $file))"
-    pathname="$(dirname ${filepath})"
-    repopath="$(echo $filepath | sed -e "s#${repo_dir}##" -e "s/^\///")"
-    pkgname=$(basename $filename .$fileext)
-    pkgnameonly="$(get_pkg_name_only $pkgname)"
-    pkgversion="$(get_pkg_version $pkgname)"
+    filepath="$(realpath "$(dirname "$file")")"
+    repopath="$(echo "$filepath" | sed -e "s#${repo_dir}##" -e "s/^\///")"
+    pkgname=$(basename "$filename" ".$fileext")
+    pkgnameonly="$(get_pkg_name_only "$pkgname")"
+    pkgversion="$(get_pkg_version "$pkgname")"
     pkgcat="$(grep -m1 "|$pkgnameonly|" ~/.packages/Packages-* | cut -f5 -d'|')"
     pkgsize="$(du "$file" 2>/dev/null | cut -f1)K"
     [ "$pkgsize" = "" ] && pkgsize="$(grep -m1 "|$pkgnameonly|" ~/.packages/Packages-* | cut -f6 -d'|')"
@@ -1429,7 +1510,7 @@ dir2repo(){                       # create a native-Puppy repo from a dir of pac
     pkgdistroversion="$DISTRO_COMPAT_VERSION"
 
     # if we don't have the required package info, dont add it to the repo file
-    [ "$pkgname" = "" -o "$pkgnameonly" = "" -o "$filename" = "" ] && continue
+    [ "$pkgname" = "" ] || [ "$pkgnameonly" = "" ] || [ "$filename" = "" ] && continue
 
     # add this package to the repo file
     echo "$pkgname|$pkgnameonly|$pkgversion||${pkgcat:-BuildingBlock}|$pkgsize|$repopath|$filename|$pkgdeps|${pkgdesc:-No description}|$pkgdistro|$pkgdistroversion|" >> "$repo_file"
@@ -1451,7 +1532,8 @@ dir2repo(){                       # create a native-Puppy repo from a dir of pac
   repo_file="${repo_dir}/Packages-${DISTRO_BINARY_COMPAT:-puppy}-$repo_name"
 
   # build repo entry
-  local repo_entry="$repo_name|$fileext|$repo_file|$repo_url||||$repo_fallbacks"
+  # shellcheck disable=SC2154
+  local repo_entry="$repo_name|$fileext|$repo_file|$repo_url||||noarch $repo_fallbacks"
 
   # get the URL where the repo file and packages will live
   echo
@@ -1523,8 +1605,9 @@ add_pkg_repo() {                  # add a Pkg-created repo, called by add_repo()
 
   # build a valid repo entry for the ~/.pkg/sources* files
   # (must have some fallbacks, strip quotes, newlines, no trailing pipes)
-  local repo_entry="$(cat /tmp/pkg/repo_info \
-    | sed -e "s/FALLBACKS=''/FALLBACKS='noarch common32'/" -e 's/.*=//g' \
+  local repo_entry="$(sed \
+      -e "s/FALLBACKS=''/FALLBACKS='noarch common32'/" \
+      -e 's/.*=//g' /tmp/pkg/repo_info \
     | tr -d '"' \
     | tr -d "'" \
     | tr '\n' '|' \
@@ -1538,11 +1621,11 @@ add_pkg_repo() {                  # add a Pkg-created repo, called by add_repo()
   # get repo info
   local repo_name="$(echo "$repo_entry" | cut -f1 -d'|')"
   local repo_filename="$(echo "$repo_entry" | cut -f3 -d'|')"
-  local repo_file_url="$(echo ${1} | sed 's#/install$##')/${repo_filename}"
+  local repo_file_url="${1/\/install/\/$repo_filename}"
 
   # download the repo file
   wget --no-check-certificate -O "/tmp/pkg/$repo_filename" -4 "$repo_file_url" &>/dev/null
-  if [ -z /tmp/pkg/$repo_filename ] || [ ! -f /tmp/pkg/$repo_filename ];then
+  if [ -z "$repo_filename" ] || [ ! -f /tmp/pkg/$repo_filename ];then
     echo "Error: Repo file $repo_filename not downloaded!"
     return 1
   fi
@@ -1563,7 +1646,7 @@ add_pkg_repo() {                  # add a Pkg-created repo, called by add_repo()
   print_repo_info $repo_name
   echo
 
-  if [ "$(cat ~/.pkg/sources 2>/dev/null | grep -m1 "^$repo_name|")" != "" ];then
+  if grep -q -m1 "^$repo_name|"  ~/.pkg/sources 2>/dev/null ;then
     echo "Success! Repo added and available to use."
     echo
     echo "To use this repo, simply type the following and hit ENTER:"
@@ -1586,7 +1669,7 @@ add_repo(){                       # add Pkg/Ubuntu/Debian/Slackware third-party 
 
   local slack_repo_url
 
-  if [ ! "$1" -o "$1" = "-" -o "$1" = "-h" -o "$1" = "--help" ];then
+  if [ ! "$1" ] || [ "$1" = "-" ] || [ "$1" = "-h" ] || [ "$1" = "--help" ];then
     print_usage add_repo && exit 1
   fi
 
@@ -1643,7 +1726,7 @@ add_repo(){                       # add Pkg/Ubuntu/Debian/Slackware third-party 
         # register in an apt-supported file too
         mkdir -p /etc/apt/
         touch /etc/apt/sources.list
-        echo "deb $@" >> /etc/apt/sources.list
+        echo "deb $*" >> /etc/apt/sources.list
         local deb_repos="$(sort -u /etc/apt/sources.list)"
         echo "$deb_repos" > /etc/apt/sources.list
       fi
@@ -1659,7 +1742,7 @@ add_repo(){                       # add Pkg/Ubuntu/Debian/Slackware third-party 
 
 
 rm_repo(){                        # remove an installed repo by name ($1) FUNCLIST
-  if [ ! "$1" -o "$1" = "-" -o "$1" = "-h" -o "$1" = "--help" ];then
+  if [ ! "$1"  ] || [ "$1" = "-" ] || [ "$1" = "-h" ] || [ "$1" = "--help" ];then
     print_usage rm_repo
     exit 1
   fi
@@ -1716,19 +1799,18 @@ rm_repo(){                        # remove an installed repo by name ($1) FUNCLI
 
 
 add_source(){                     # add a new repo to your repo 'sources' list FUNCLIST
-  [ ! "$1" \
-    -o "$1" = "-" \
-    -o "$1" = "-h" \
-    -o "$1" = "--help" \
-    -o "`echo "$1" |  grep '|'`" = "" \
-    -o "`echo "$1" | cut -f2 -d'|'`" = "" \
-    -o "`echo "$1" | cut -f4 -d'|'`" = "" \
-    -o "`echo "$1" | cut -f8 -d'|'`" = "" ] && \
+  [ ! "$1" ] \
+  || [ "$1" = "-" ] \
+  || [ "$1" = "-h" ] \
+  || [ "$1" = "--help" ] \
+  || [ "$(echo "$1" |  grep '|')" = "" ] \
+  || [ "$(echo "$1" | cut -f2 -d'|')" = "" ] \
+  || [ "$(echo "$1" | cut -f4 -d'|')" = "" ] \
+  || [ "$(echo "$1" | cut -f8 -d'|')" = "" ] && \
     print_usage add_source && exit 1
 
   # get repo file to add to sources
-  REPOTOADD="`echo $1 | cut -f1 -d'|'`"
-  REPOFILETOADD="`echo $1 | cut -f3 -d'|'`"
+  REPOTOADD="$(echo "$1" | cut -f1 -d'|')"
 
   # do checks before adding repo (dont add duplicate, make sure file exists, etc)
 
@@ -1738,6 +1820,7 @@ add_source(){                     # add a new repo to your repo 'sources' list F
   #  echo "Repo with the name '$REPOTOADD' already in the list"
   #fi
 
+  #REPOFILETOADD="$(echo $1 | cut -f3 -d'|')"
   # check if repo filename already  exists in sources-all
   #if [ "`repo_file_list | grep -m1 "^$REPOFILETOADD\$"`" != "" ];then
   #  echo "Repo with database file $HOME/.packages/'$REPOFILETOADD' already in the list"
@@ -1765,22 +1848,26 @@ add_source(){                     # add a new repo to your repo 'sources' list F
 update_sources(){                 # create the list of available repos FUNCLIST
 
   # get current repo values and Pkg settings
-  . ${PKGRC}
+  . "${PKGRC}"
 
   #list current repo first in sources
   get_repo_info "${REPONAME:-noarch}"
 
 
   # only add the current repo to the list of available sources if it exists
-  if [ "`find $HOME/.packages/ -iname "$REPOFILE" `" != '' ];then
+  if [ "$(find $HOME/.packages/ -iname "$REPOFILE")" != '' ]
+  then
     echo "$REPONAME|$EX|$REPOFILE|$REPOURL1|$REPOURL2|$REPOURL3|$REPOURL4|$REPOFALLBACKS" > ${HOME}/.pkg/sources
-  elif [ "`find /var/packages/ -iname "$REPOFILE" `" != '' ];then
+  elif [ "$(find /var/packages/ -iname "$REPOFILE")" != '' ]
+  then
     echo "$REPONAME|$EX|$REPOFILE|$REPOURL1|$REPOURL2|$REPOURL3|$REPOURL4|$REPOFALLBACKS" > ${HOME}/.pkg/sources
   fi
 
 
   # get repos in order of fallbacks, pkg will then 'fall back' to each repo in that order
-  FALLBACKS="`grep -m1 "^${REPONAME}|" ${HOME}/.pkg/sources-all 2>/dev/null | grep -v ^'#' | cut -f8 -d'|'`"
+  local REPOFALLBACKS="$(grep -m1 "^${REPONAME}|" ${HOME}/.pkg/sources-all 2>/dev/null \
+    | grep -v ^'#' \
+    | cut -f8 -d'|')"
 
   # for each repo in fallback list
   for FBACK in $REPOFALLBACKS; do
@@ -1788,45 +1875,45 @@ update_sources(){                 # create the list of available repos FUNCLIST
     [ "$FBACK" = "$REPONAME" ] && continue
 
     # check if repo is supported (has entries in sources-all)
-    LINE="`grep -m1 "^$FBACK|" ${HOME}/.pkg/sources-all 2>/dev/null | grep -v ^'#' | grep -v "^${REPONAME}|"`"
+    LINE="$(grep -m1 "^$FBACK|" ${HOME}/.pkg/sources-all 2>/dev/null | grep -v ^'#' | grep -v "^${REPONAME}|")"
     [ "$LINE" = "" ] && continue
 
     # if repo is valid, add to users list of in-use repos (only valid repos from sources-all => sources)
-    if [ -f "${HOME}/.packages/`echo "$LINE" | cut -f3 -d'|'`" ];then
+    if [ -f "${HOME}/.packages/$(echo "$LINE" | cut -f3 -d'|')" ];then
 
       if [ "$(grep -m1 "^$FBACK|" ${HOME}/.pkg/sources)" = "" ];then
-        echo "Adding repo: `echo "$LINE"|cut -f1 -d'|'`.."
+        echo "Adding repo: ${LINE//|*/}.."
         echo "$LINE" >> ${HOME}/.pkg/sources
       fi
     fi
   done
 
-  cleaned_repo_list="`cat ${HOME}/.pkg/sources-all 2>/dev/null | grep -v ^'#'| grep -v ^$`"
+  cleaned_repo_list="$(grep -v ^'#' ${HOME}/.pkg/sources-all 2>/dev/null | grep -v ^$)"
 
   # now add any other repos to the list (repos that are installed, but not added from fallback list)
   echo "$cleaned_repo_list" | uniq | while read repo_entry
   do
     # dont add current repo, its already added
-    [ "`echo "$repo_entry" | cut -f1 -d'|'`" = "$REPONAME" ] && echo "Adding repo: $REPONAME.." && continue
+    [ "${repo_entry//|*/}" = "$REPONAME" ] && echo "Adding repo: $REPONAME.." && continue
 
     # get the repo name
-    repo_name="`echo "$repo_entry"|cut -f1 -d'|'`"
+    repo_name="${repo_entry//|*/}"
 
     # build the repo file (full path)
-    repo_file=${HOME}/.packages/`echo "$repo_entry" | cut -f3 -d'|'`
+    repo_file=${HOME}/.packages/$(echo "$repo_entry" | cut -f3 -d'|')
 
     # set a flag true if repo already in repo, false if not
     already_in_repo=false
-    [ "`grep -m1 "^$repo_entry" ${HOME}/.pkg/sources 2>/dev/null`" != "" ] && already_in_repo=true
+    grep -q -m1 "^$repo_entry" ${HOME}/.pkg/sources 2>/dev/null && already_in_repo=true
 
-    if [ -f "$repo_file" -a "$already_in_repo" = false ];then
+    if [ -f "$repo_file" ] && [ "$already_in_repo" = false ];then
       echo "Adding repo: $repo_name.."
       echo "$repo_entry" >> ${HOME}/.pkg/sources
     fi
   done
 
   # finished, print message
-  [ -f ${HOME}/.pkg/sources ] && echo "Sources updated." && . ${PKGRC}
+  [ -f ${HOME}/.pkg/sources ] && echo "Sources updated." && . "${PKGRC}"
 }
 
 
@@ -1835,10 +1922,10 @@ set_ppa2pup_fn(){
   case "$PKG_PPA2PUP_FN" in
   ppa2pup_gawk) ppa2pup_fn=ppa2pup_gawk; ;;
   ppa2pup) ppa2pup_fn=ppa2pup ;;
-  *) 
+  *)
     echo "Invalid value: PKG_PPA2PUP_FN=${PKG_PPA2PUP_FN}"
     echo "Valid values: ppa2pup or ppa2pup_gawk"
-    exit 1 ;; 
+    exit 1 ;;
   esac
 }
 
@@ -1846,7 +1933,7 @@ set_ppa2pup_fn(){
 update_repo(){                    # update the current repo from a file stored online FUNCLIST
 
   # check internet, net connection required
-  NET="`check_net`"; [ $NET -eq 1 ] && echo "You need an internet connection" && exit 1
+  NET="$(check_net)"; [ $NET -eq 1 ] && echo "You need an internet connection" && exit 1
 
   # remove the repo update tmp file
   rm -f $TMPDIR/update_repo_results 2>/dev/null
@@ -1873,15 +1960,20 @@ update_repo(){                    # update the current repo from a file stored o
 
   # if the repos updated ok
   if [ $? -eq 0 ];then
-    [ "`which logger`" != '' ] && logger "$0 Repo files updated by $APP $APPVER"
-    echo -e "Repo files updated:"
-    grep " PKG DB " $TMPDIR/update_repo_results | cut -f2 -d ':'
+    [ "$(which logger)" != '' ] && logger "$0 Repo files updated by $APP $APPVER"
+    # print list of system repos that were updated
+    echo -e "Repo files updated:\n"
+    if [ "$PKG_REPO_UPDATE_METHOD" = standard ];then
+      grep " PKG DB " $TMPDIR/update_repo_results | cut -f2 -d ':'
+    else
+      grep "^Processing Packages" $TMPDIR/update_repo_results | cut -f1,2 -d' ' | sed 's#Processing #Updated:     #'
+    fi
     # remove the repo update tmp file
     rm -f $TMPDIR/update_repo_results 2>/dev/null
   else
     # repo did not update ok
     error "Repos NOT updated."
-    cat $TMPDIR/update_repo_results | tail -20
+    tail -20 $TMPDIR/update_repo_results
     exit 2
   fi
 
@@ -1894,10 +1986,10 @@ update_repo(){                    # update the current repo from a file stored o
 
   # update Pkg created repos
   if [ -f ~/.pkg/sources-user ];then
-    pkg_repos="$(sort -u ~/.pkg/sources-user | grep -v ^$ | uniq | cut -f1 -d'|')"
+    pkg_repos="$(sort -u ~/.pkg/sources-user | grep -v ^$ | cut -f1 -d'|')"
     for pkg_repo in $pkg_repos
     do
-      local pkg_repo_url="$(cat ~/.pkg/sources-user | grep -m1 "^$pkg_repo|" | cut -f4 -d'|')"
+      local pkg_repo_url="$(grep -m1 "^$pkg_repo|" ~/.pkg/sources-user | cut -f4 -d'|')"
       echo "Processing:  $pkg_repo_url"
 
       ANSWER=y
@@ -1908,8 +2000,7 @@ update_repo(){                    # update the current repo from a file stored o
       fi
 
       if [ "$ANSWER" = 'y' ] || [ "$ANSWER" = 'Y' ];then
-        echo "Please wait..."
-        add_pkg_repo ${pkg_repo_url}install 1>/dev/null && echo -e "${green}Success${endcolour}: Updated repo '$pkg_repo'"
+        add_pkg_repo ${pkg_repo_url}install 1>/dev/null && echo -e "${green}Updated${endcolour}:     $pkg_repo"
       fi
     done
   fi
@@ -1930,8 +2021,7 @@ update_repo(){                    # update the current repo from a file stored o
         -e "s/^deb //g" \
         -e "s/^tor+//g" \
         -e 's/\[arch=[a-z,0-9].*\] //g' \
-        -e 's/ /|/g'\
-    )"
+        -e 's/ /|/g')"
 
     # for each repo in $apt_sources_list, use `ppa2pup` to update the repo
     for line in $apt_sources_list
@@ -1940,7 +2030,7 @@ update_repo(){                    # update the current repo from a file stored o
       [ "$line" = "\n" ] && continue
 
       local ppa_repo_url="$(echo ${line//|/ } | cut -f1 -d" ")"
-      local ppa_repo_name=$(cat ~/.pkg/sources-all | grep -m1 $ppa_repo_url | cut -f1 -d'|')
+      local ppa_repo_name=$(grep -m1 "$ppa_repo_url" ~/.pkg/sources-all | cut -f1 -d'|')
 
       # if a PPA repo, get a user-friendly repo name from the /etc/sources.list entry
       if [ "$ppa_repo_name" = "" ];then
@@ -1957,11 +2047,10 @@ update_repo(){                    # update the current repo from a file stored o
         echo
         ANSWER="$(cat /tmp/pkg/ANSWER)"
       fi
-      
+
       if [ "$ANSWER" = 'y' ] || [ "$ANSWER" = 'Y' ];then
-        echo "Please wait..."
         set_ppa2pup_fn
-        $ppa2pup_fn ${line//|/ } 1>/dev/null && echo -e "${green}Success${endcolour}: Updated repo '$ppa_repo_name'"
+        $ppa2pup_fn ${line//|/ } 1>/dev/null && echo -e "${green}Updated${endcolour}:     $ppa_repo_name"
         retval=$?
       fi
     done
@@ -1983,7 +2072,7 @@ update_repo(){                    # update the current repo from a file stored o
           slack_repo_url="${slack_repo_url}/"
         fi
 
-        local slack_repo_name=$(cat ~/.pkg/sources-all | grep -m1 $slack_repo_url | cut -f1 -d'|')
+        local slack_repo_name=$(grep -m1 $slack_repo_url ~/.pkg/sources-all | cut -f1 -d'|')
 
         echo
         echo "Processing:  $slack_repo_url"
@@ -1997,8 +2086,7 @@ update_repo(){                    # update the current repo from a file stored o
         fi
 
         if [ "$ANSWER" = 'y' ] || [ "$ANSWER" = 'Y' ];then
-          echo "Please wait..."
-          slack2pup "${slack_repo_url}/PACKAGES.TXT" $slack_repo_name 1>/dev/null && echo -e "${green}Success${endcolour}: Updated repo '$slack_repo_name'"
+          slack2pup "${slack_repo_url}/PACKAGES.TXT" $slack_repo_name 1>/dev/null && echo -e "${green}Updated${endcolour}:     $slack_repo_name"
         fi
       done
     fi
@@ -2023,52 +2111,59 @@ list_all_sources(){               # return all (or matching) repos (~/.pkg/sourc
 convert_repofile(){               # convert repo files formats (pre-woof/post-woof) FUNCLIST
 
   # get the file name (FILENAME) and full path (FILE)
-  FILENAME="`basename "$1"`"
+  FILENAME="$(basename "$1")"
   FILE="${CURDIR}/${FILENAME}"
 
   # check for valid options
   [ ! -f "$FILE" ] && print_usage repo-convert && exit 1
 
   # dont replace repo unless -f was given
-  [ "$FORCE" != true -a -f "${HOME}/.packages/${FILENAME}" ] && echo "File '${HOME}/.packages/$FILENAME' already exists."  && exit 1
+  if [ "$FORCE" != true ] && [ -f "${HOME}/.packages/${FILENAME}" ];then
+    echo "File '${HOME}/.packages/$FILENAME' already exists."
+    exit 1
+  fi
 
   # remove tmp files
   rm $TMPDIR/$FILENAME &>/dev/null
   rm $TMPDIR/${FILENAME}_subdirs &>/dev/null
 
   # check repo file format (woof or pre-woof)
-  if [ -f "$FILE" -a "`cat "$FILE" | head -1 | grep -m1 '^"'`" = "" ];then #if is a new format  #'
+  if [ -f "$FILE" ] && [ "$(head -1 "$FILE" | grep -m1 '^"')" = "" ];then #if is a new format  #'
 
     # convert woof repo file to pre-woof repo file.. takes ages..
     echo "Converting '${FILE}' to pre-woof format.. This might take a while.."
+
+    # shellcheck disable=SC2002
     cat "$FILE" | while read LINE
     do
-      PKGNAME="`echo $LINE| cut -f1 -d'|'`"
-      PKGNAME1=''
+      PKGNAME="$(echo $LINE| cut -f1 -d'|')"
       # we need to get the package name, try lots of different extensions
-      [ "`echo $PKGNAME1 | grep ".deb\$"`" != "" ]  && PKGNAME1="`echo $LINE| cut -f8 -d'|'`"
-      [ "`echo $PKGNAME1 | grep ".deb\$"`" != "" ]  && PKGNAME="`basename $PKGNAME1 .deb`"
-      [ "`echo $PKGNAME1 | grep ".rpm\$"`" != "" ]  && PKGNAME="`basename $PKGNAME1 .rpm`"
-      [ "`echo $PKGNAME1 | grep ".txz\$"`" != "" ]  && PKGNAME="`basename $PKGNAME1 .txz`"
-      [ "`echo $PKGNAME1 | grep ".tgz\$"`" != "" ]  && PKGNAME="`basename $PKGNAME1 .tgz`"
-      [ "`echo $PKGNAME1 | grep ".tar.xz\$"`" != "" ] && PKGNAME="`basename $PKGNAME1 .tar.xz`"
-      [ "`echo $PKGNAME1 | grep ".tar.gz\$"`" != "" ] && PKGNAME="`basename $PKGNAME1 .tar.gz`"
+      [ "$(echo $PKGNAME | grep ".deb\$")" != "" ]  && PKGNAME="$(echo "$LINE" | cut -f8 -d'|')"
+      [ "$(echo $PKGNAME | grep ".deb\$")" != "" ]  && PKGNAME="$(basename $PKGNAME .deb)"
+      [ "$(echo $PKGNAME | grep ".rpm\$")" != "" ]  && PKGNAME="$(basename $PKGNAME .rpm)"
+      [ "$(echo $PKGNAME | grep ".txz\$")" != "" ]  && PKGNAME="$(basename $PKGNAME .txz)"
+      [ "$(echo $PKGNAME | grep ".tgz\$")" != "" ]  && PKGNAME="$(basename $PKGNAME .tgz)"
+      [ "$(echo $PKGNAME | grep ".tar.xz\$")" != "" ] && PKGNAME="$(basename $PKGNAME .tar.xz)"
+      [ "$(echo $PKGNAME | grep ".tar.gz\$")" != "" ] && PKGNAME="$(basename $PKGNAME .tar.gz)"
       # get size
-      SIZE=" `echo $LINE| cut -f6 -d'|'`"
+      SIZE=" $(echo $LINE| cut -f6 -d'|')"
       # get category
-      CAT="`echo $LINE| cut -f5 -d'|'`"
+      CAT="$(echo $LINE| cut -f5 -d'|')"
       #150813 remove extra categories .. example 'Setup;Installation' .. remove 'Installation'
-      [ "`echo "$CAT" | grep ';'`" != "" ] && CAT="`echo "$CAT" | cut -f1 -d';'`"
+      [ "(echo $CAT | grep ';')" != "" ] && CAT="$(echo $CAT | cut -f1 -d';')"
       # get sub dir in repo
-      SUBDIR="`echo $LINE| cut -f7 -d'|'`" #150213
+      SUBDIR="$(echo $LINE| cut -f7 -d'|')"
       # get deps
-      DEPS=" `echo $LINE| cut -f9 -d'|'| grep '+'`"
+      DEPS=" $(echo $LINE| cut -f9 -d'|'| grep '+')"
       # get desc
-      DESC="`echo $LINE| cut -f10 -d'|'`"
+      DESC="$(echo $LINE| cut -f10 -d'|')"
       # add repo entry to tmp file
       [ "$PKGNAME" != "" ] && echo "\"$PKGNAME\" \"$PKGNAME: ${DESC//:/,}\" off \"$CAT$DEPS$SIZE\" /" | sed -e 's/  / /g' -e 's/,,/,/g' -e 's/, ,/,/g' | sort --field-separator='-' -k1,1d -k2gr -k3gr -k4gr | uniq >> $TMPDIR/$FILENAME
       #150213 now do subdirs... slow..
-      [ "`echo $SUBDIR | grep "/"`" != "" -a "`echo $SUBDIR | grep -i pet_packages`" = "" ] && echo "$PKGNAME|/$SUBDIR" >> $TMPDIR/${FILENAME}_subdirs
+      if [ "$(echo $SUBDIR | grep "/")" != "" ] && [ "$(echo $SUBDIR | grep -i pet_packages)" = "" ]
+      then
+        echo "$PKGNAME|/$SUBDIR" >> $TMPDIR/${FILENAME}_subdirs
+      fi
     done
     # done making a pre-woof repo file, print message
     [ -f $TMPDIR/$FILENAME ] && echo "Finished converting $FILENAME to pre-woof format." || exit 1
@@ -2079,46 +2174,47 @@ convert_repofile(){               # convert repo files formats (pre-woof/post-wo
     echo "Converting '$FILENAME' to a 'woof' compatible repo file. This could take a while..."
 
     # parse a pre-woof repo file
+    # shellcheck disable=SC2002
     cat "$FILE" | while read LINE
     do
       PKGNAME='' PKGNAMEONLY='' PKGVER='' SIZE='' CAT='' DEPS='' BUILD='' SUBDIR='' PKGEXT='.pet' DESC=''
 
-      PKGNAME="`echo "$LINE" | cut -d'"' -f2`" #'micro
-      [ "`echo $PKGNAME | grep ".deb\$"`" != "" ]     && PKGEXT='.deb'    && PKGNAME="`basename $PKGNAME1 .deb`"
-      [ "`echo $PKGNAME | grep ".pet\$"`" != "" ]     && PKGEXT='.pet'    && PKGNAME="`basename $PKGNAME1 .pet`"
-      [ "`echo $PKGNAME | grep ".rpm\$"`" != "" ]     && PKGEXT='.rpm'    && PKGNAME="`basename $PKGNAME1 .rpm`"
-      [ "`echo $PKGNAME | grep ".tcz\$"`" != "" ]     && PKGEXT='.tcz'    && PKGNAME="`basename $PKGNAME1 .tcz`"
-      [ "`echo $PKGNAME | grep ".tgz\$"`" != "" ]     && PKGEXT='.tgz'    && PKGNAME="`basename $PKGNAME1 .tgz`"
-      [ "`echo $PKGNAME | grep ".txz\$"`" != "" ]     && PKGEXT='.txz'    && PKGNAME="`basename $PKGNAME1 .txz`"
-      [ "`echo $PKGNAME | grep ".tar.gz\$"`" != "" ]    && PKGEXT='.tar.gz'   && PKGNAME="`basename $PKGNAME1 .tar.gz`"
-      [ "`echo $PKGNAME | grep ".tar.xz\$"`" != "" ]    && PKGEXT='.tar.xz'   && PKGNAME="`basename $PKGNAME1 .tar.xz`"
-      [ "`echo $PKGNAME | grep ".pkg.tar.gz\$"`" != "" ]  && PKGEXT='.pkg.tar.gz' && PKGNAME="`basename $PKGNAME1 .pkg.tar.gz`"
-      [ "`echo $PKGNAME | grep ".pkg.tar.xz\$"`" != "" ]  && PKGEXT='.pkg.tar.xz' && PKGNAME="`basename $PKGNAME1 .pkg.tar.xz`"
+      PKGNAME="$(echo "$LINE" | cut -d'"' -f2)" #'micro
+      [ "$(echo $PKGNAME | grep ".deb\$")" != "" ]    && PKGEXT='.deb'     && PKGNAME="$(basename $PKGNAME .deb)"
+      [ "$(echo $PKGNAME | grep ".pet\$")" != "" ]    && PKGEXT='.pet'     && PKGNAME="$(basename $PKGNAME .pet)"
+      [ "$(echo $PKGNAME | grep ".rpm\$")" != "" ]    && PKGEXT='.rpm'     && PKGNAME="$(basename $PKGNAME .rpm)"
+      [ "$(echo $PKGNAME | grep ".tcz\$")" != "" ]    && PKGEXT='.tcz'     && PKGNAME="$(basename $PKGNAME .tcz)"
+      [ "$(echo $PKGNAME | grep ".tgz\$")" != "" ]    && PKGEXT='.tgz'     && PKGNAME="$(basename $PKGNAME .tgz)"
+      [ "$(echo $PKGNAME | grep ".txz\$")" != "" ]    && PKGEXT='.txz'     && PKGNAME="$(basename $PKGNAME .txz)"
+      [ "$(echo $PKGNAME | grep ".tar.gz\$")" != "" ] && PKGEXT='.tar.gz'  && PKGNAME="$(basename $PKGNAME .tar.gz)"
+      [ "$(echo $PKGNAME | grep ".tar.xz\$")" != "" ] && PKGEXT='.tar.xz'  && PKGNAME="$(basename $PKGNAME .tar.xz)"
+      [ "$(echo $PKGNAME | grep ".pkg.tar.gz\$")" != "" ] && PKGEXT='.pkg.tar.gz' && PKGNAME="$(basename $PKGNAME .pkg.tar.gz)"
+      [ "$(echo $PKGNAME | grep ".pkg.tar.xz\$")" != "" ] && PKGEXT='.pkg.tar.xz' && PKGNAME="$(basename $PKGNAME .pkg.tar.xz)"
 
       # get pkg name only .. without versions or suffix
-      PKGNAME_ONLY="`echo "${PKGNAME}" | sed -e 's/-[0-9.]*/-/g' -e 's/-$//'`"
+      PKGNAME_ONLY="$(echo "${PKGNAME}" | sed -e 's/-[0-9.]*/-/g' -e 's/-$//')"
       # if that didnt work, use the old method
-      if [ "$PKGNAME_ONLY" = '' -o "$PKGNAME_ONLY" = "$PKGNAME" ];then
+      if [ "$PKGNAME_ONLY" = '' ] || [ "$PKGNAME_ONLY" = "$PKGNAME" ];then
         # get pkg name without version
-        PKGNAMEONLY="`echo $PKGNAME | cut -d'-' -f1`"
+        PKGNAME_ONLY="${PKGNAME//-*/}"
       fi
       PKGNAME_ONLY="${PKGNAME_ONLY//-*/}"
 
       # get pkg version
-      PKGVER="`LANG=C echo "$LINE" | sed -e 's/^[^0-9]*-//g' | cut -f1 -d'_' | cut -f1 -d'-'`"
+      PKGVER="$(LANG=C echo "$LINE" | sed -e 's/^[^0-9]*-//g' | cut -f1 -d'_' | cut -f1 -d'-')"
       # get pkg size
-      SIZE="`echo $LINE| cut -d'"' -f6 | cut -d' ' -f3`" #'micro
+      SIZE="$(echo $LINE| cut -d'"' -f6 | cut -d' ' -f3)" #'micro
       SIZE=${SIZE## }
       SIZE=${SIZE%% }
       # must check again if pkg had no deps
-      [ "$SIZE" = "" ] && SIZE=" `echo $LINE| cut -d'"' -f6|cut -d' ' -f2`"
+      [ "$SIZE" = "" ] && SIZE=" $(echo $LINE| cut -d'"' -f6|cut -d' ' -f2)"
       # get pkg category
-      CAT="`echo $LINE | cut -d'"' -f6 | cut -d' ' -f1`"
+      CAT="$(echo $LINE | cut -d'"' -f6 | cut -d' ' -f1)"
       # remove extra categories
-      [ "`echo "$CAT" | grep ';'`" != "" ] && CAT="`echo "$CAT" | cut -f1 -d';'`"
+      [ "$(echo "$CAT" | grep ';')" != "" ] && CAT="$(echo "$CAT" | cut -f1 -d';')"
       # get pkg deps
-      DEPS="`echo "$LINE" | cut -d'"' -f6 | cut -d' ' -f2 | grep ^'+'`"
-      DESC="`echo "$LINE" | cut -f10 -d'|'`" #'micro
+      DEPS="$(echo "$LINE" | cut -d'"' -f6 | cut -d' ' -f2 | grep ^'+')"
+      DESC="$(echo "$LINE" | cut -f10 -d'|')" #'micro
       # build the woof compatible repo file
       [ "$PKGNAME" != "" ] && echo "$PKGNAME|$PKGNAMEONLY|$VER|$BUILD|$CAT|$SIZE|$SUBDIR|${PKGNAME}${PKGEXT}|$DEPS|$DESC|$DISTRO_BINARY_COMPAT|$DISTRO_COMPAT_VERSION||" >> $TMPDIR/$FILENAME
     done
@@ -2144,21 +2240,25 @@ convert_repofile(){               # convert repo files formats (pre-woof/post-wo
 print_repo_info(){                # get repo settings, return current repo name FUNCLIST
 
   # get latest repo info (from sources file), or from PKGRC if that fails
-  [ "$1" ] && get_repo_info "$1" || . ${PKGRC}
+  if [ "$1" ];then
+    get_repo_info "$1"
+  else
+    . ${PKGRC}
+  fi
 
-  local pkg_count=`cat ${HOME}/.packages/${REPOFILE} | wc -l`
+  local pkg_count=$(wc -l < ${HOME}/.packages/${REPOFILE})
 
   # output the repo info
   echo "- Repo:          $REPONAME"
   echo "- Repo file:     $REPOFILE"
   echo "- Package Type:  $EX"
   echo "- Packages:      $pkg_count"
-  echo "- URL Mirror 1:  `echo $REPOURL1 | cut -f1-3 -d'/'`"
-  [ "$REPOURL2" != "" ] && echo "- URL Mirror 2:  `echo $REPOURL2  | cut -f1-3 -d'/'`"
-  [ "$REPOURL3" != "" ] && echo "- URL Mirror 3:  `echo $REPOURL3  | cut -f1-3 -d'/'`"
-  [ "$REPOURL4" != "" ] && echo "- URL Mirror 4:  `echo $REPOURL4  | cut -f1-3 -d'/'`"
+  echo "- URL Mirror 1:  $(echo $REPOURL1 | cut -f1-3 -d'/')"
+  [ "$REPOURL2" != "" ] && echo "- URL Mirror 2:  $(echo $REPOURL2  | cut -f1-3 -d'/')"
+  [ "$REPOURL3" != "" ] && echo "- URL Mirror 3:  $(echo $REPOURL3  | cut -f1-3 -d'/')"
+  [ "$REPOURL4" != "" ] && echo "- URL Mirror 4:  $(echo $REPOURL4  | cut -f1-3 -d'/')"
   echo
-  echo "- Fall back to:`echo $REPOFALLBACKS | fold -w 50 -s | sed -e "s/ /, /g" -e "s/^/  /g"`"
+  echo "- Fall back to:$(echo $REPOFALLBACKS | fold -w 50 -s | sed -e "s/ /, /g" -e "s/^/  /g")"
 }
 
 
@@ -2171,7 +2271,7 @@ hide_blacklisted_pkgs_from_search_results(){ # hide BUILTIN and installed pkgs f
   [ "$FORCE" = true ] && return 0
 
   # remove blacklisted packages from search list
-  cat $TMPDIR/pkglist | grep -vE "'$PKG_BLACKLIST_REGEX'" > $TMPDIR/pkglist_without_blacklisted
+  grep -vE "'$PKG_BLACKLIST_REGEX'" $TMPDIR/pkglist > $TMPDIR/pkglist_without_blacklisted
   mv $TMPDIR/pkglist_without_blacklisted $TMPDIR/pkglist
 
   # clean up tmp files
@@ -2188,16 +2288,16 @@ hide_installed_pkgs_from_search_results(){  # hide BUILTIN and installed pkgs fr
   rm $TMPDIR/pkglist_inst &>/dev/null
 
   # get pkg names (generic names, no versions) of all installed pkgs (builtins, devx and user installed)
-  inst_pkg_list="`cut -f1 -d'|' ${HOME}/.packages/user-installed-packages \
+  inst_pkg_list="$(cut -f1 -d'|' ${HOME}/.packages/user-installed-packages \
     ${HOME}/.packages/devx-only-installed-packages \
     ${HOME}/.packages/woof-installed-packages 2>/dev/null \
     | grep -v ^$ \
     | tr '\n' '|' \
     | sed -e "s/||/|/g" \
-    | sed -e "s/|\$//g"`"
+          -e "s/|\$//g")"
 
   # remove woof and user installed packages from search list
-  cat $TMPDIR/pkglist | grep -v -E "'$inst_pkg_list'" > $TMPDIR/pkglist_without_inst
+  grep -v -E "'$inst_pkg_list'" $TMPDIR/pkglist  > $TMPDIR/pkglist_without_inst
   mv $TMPDIR/pkglist_without_inst $TMPDIR/pkglist
 
   # clean up tmp files
@@ -2214,7 +2314,7 @@ list_pkg_names(){                 # list pkg names in current repo only ($1 is o
   . ${PKGRC}
 
   # create the search results
-  cut -f1 -d'|' ${HOME}/.packages/${REPOFILE} 2>/dev/null | grep "^$1" > $TMPDIR/pkglist
+  cut -f1 -d'|' ${HOME}/.packages/${REPOFILE} 2>/dev/null | grep "^${1}" > $TMPDIR/pkglist
 
   # filter out builtin and user installed packages
   if [ $HIDE_INSTALLED = true ];then
@@ -2229,24 +2329,24 @@ list_pkg_names(){                 # list pkg names in current repo only ($1 is o
     local ALIAS
     local ALIAS_RES
     # if we have some results to parse
-    if [ "$1" != "" -a -f $TMPDIR/pkg_aliases ];then
+    if [ "$1" != "" ] && [ -f $TMPDIR/pkg_aliases ];then
       # get the list of aliases
-      ALIAS_LIST="`grep -m1 "$1" $TMPDIR/pkg_aliases  2>/dev/null | tr ',' ' '`";
+      ALIAS_LIST="$(grep -m1 "$1" $TMPDIR/pkg_aliases  2>/dev/null | tr ',' ' ')";
       # for each alias
       echo $ALIAS_LIST | while read ALIAS
       do
         [ "$ALIAS" = '' ] && continue
         # get the match from the current repo (if any)
-        ALIAS_RES="`LANG=C cut -f1 -d'|' ${HOME}/.packages/${REPOFILE} 2>/dev/null | grep "^$ALIAS"`" #'
-        [ ! "$ALIAS_RES" ] && ALIAS_RES="`LANG=C cut -f2 -d'|' ${HOME}/.packages/${REPOFILE} 2>/dev/null | grep "^$ALIAS"`" #'
+        ALIAS_RES="$(LANG=C cut -f1 -d'|' ${HOME}/.packages/${REPOFILE} 2>/dev/null | grep "^$ALIAS")" #'
+        [ -z "$ALIAS_RES" ] && ALIAS_RES="$(LANG=C cut -f2 -d'|' ${HOME}/.packages/${REPOFILE} 2>/dev/null | grep "^$ALIAS")" #'
         # if the repo match was found in the search results
-        if [ "$ALIAS_RES" != "" ];then
+        if [ ! -z "$ALIAS_RES" ];then
           # add the alias results to the search results
           echo "$ALIAS_RES" >> $TMPDIR/pkglist
         fi
       done # for each alias
       # sort and clean the search results
-      LANG=C cat $TMPDIR/pkglist | sort --field-separator='-' -k1,1df -k2gr -k3gr -k4gr | uniq > $TMPDIR/pkglist1
+      LANG=C sort -u -t '-' -k1,1df -k2gr -k3gr -k4gr $TMPDIR/pkglist > $TMPDIR/pkglist1
       # replace the original search results
       mv $TMPDIR/pkglist1 $TMPDIR/pkglist
     fi
@@ -2256,7 +2356,7 @@ list_pkg_names(){                 # list pkg names in current repo only ($1 is o
   [ -s $TMPDIR/pkglist ] && cat $TMPDIR/pkglist 2>/dev/null
 
   # clean up
-  [ ! -f $TMPDIR/pkglist ] && exit 1
+  [ ! -f $TMPDIR/pkglist ] && return 1
   rm $TMPDIR/pkglist* 2>/dev/null
 
 }
@@ -2270,13 +2370,13 @@ list_all_pkg_names(){             # list pkg names in any repo  ($1 is optional 
   # if bleeding edge disabled, output the list repo by repo, in the fallback order, current repo first (that order is set in update_sources)
   repo_file_list | while read repo_file
   do
-    cut -f1 -d'|' ${HOME}/.packages/${repo_file} 2>/dev/null | grep "^$1" | sort --field-separator='-' -k1,1df -k2gr -k3gr -k4gr >> $TMPDIR/pkglist
+    cut -f1 -d'|' ${HOME}/.packages/${repo_file} 2>/dev/null | grep "^$1" | sort -u -t '-' -k1,1df -k2gr -k3gr -k4gr >> $TMPDIR/pkglist
   done
 
   # if bleeding edge enabled, re-order the whole list, so Pkg returns the most recent pgk versions from ANY repos
   if [ "$BLEDGE" = "yes" ];then
-    LANG=C cat $TMPDIR/pkglist  2>/dev/null | sort --field-separator='-' -k1,1df -k2gr -k3gr -k4gr > $TMPDIR/pkglist1
-    mv $TMPDIR/pkglist1 $TMPDIR/pkglist
+    LANG=C sort -u -t '-' -k1,1df -k2gr -k3gr -k4gr $TMPDIR/pkglist 2>/dev/null > $TMPDIR/pkglist_sorted
+    mv $TMPDIR/pkglist_sorted $TMPDIR/pkglist
   fi
 
   # filter out built-in and user installed packages
@@ -2292,19 +2392,19 @@ list_all_pkg_names(){             # list pkg names in any repo  ($1 is optional 
     local ALIAS
     local ALIAS_RES
     # if we have some results to parse
-    if [ "$1" != "" -a -f $TMPDIR/pkg_aliases ];then
+    if [ "$1" != "" ] && [ -f $TMPDIR/pkg_aliases ];then
       # get the list of aliases
-      ALIAS_LIST="`grep -m1 "$1" $TMPDIR/pkg_aliases  2>/dev/null | tr ',' ' '`";
+      ALIAS_LIST="$(grep -m1 "$1" $TMPDIR/pkg_aliases  2>/dev/null | tr ',' ' ')";
       # for each repo
       LANG=C repo_file_list | while read RF
       do
         # and for each alias
         for ALIAS in $ALIAS_LIST; do
           # get the match from the current repo (if any)
-          ALIAS_RES="`LANG=C cut -f1 -d'|' ${HOME}/.packages/${RF} 2>/dev/null | grep -m1 "^$ALIAS"`"
-          [ ! "$ALIAS_RES" ] && ALIAS_RES="`LANG=C cut -f2 -d'|' ${HOME}/.packages/${RF} 2>/dev/null | grep -m1 "^$ALIAS"`"
+          ALIAS_RES="$(LANG=C cut -f1 -d'|' ${HOME}/.packages/${RF} 2>/dev/null | grep -m1 "^$ALIAS")"
+          [ -z "$ALIAS_RES" ] && ALIAS_RES="$(LANG=C cut -f2 -d'|' ${HOME}/.packages/${RF} 2>/dev/null | grep -m1 "^$ALIAS")"
           # if the repo match was found in the search results
-          if [ "$ALIAS_RES" != "" ];then
+          if [ ! -z "$ALIAS_RES" ];then
             # add the alias results to the search results
             echo "$ALIAS_RES" >> $TMPDIR/pkglist
           fi
@@ -2314,10 +2414,10 @@ list_all_pkg_names(){             # list pkg names in any repo  ($1 is optional 
   fi
 
   # return the search results
-  [ -s $TMPDIR/pkglist ] && LANG=C cat $TMPDIR/pkglist | sort --field-separator='-' -k1,1df -k2gr -k3gr -k4gr | uniq
+  [ -s $TMPDIR/pkglist ] && LANG=C sort -u -t '-' -k1,1df -k2gr -k3gr -k4gr $TMPDIR/pkglist
 
   # clean up
-  [ ! -f $TMPDIR/pkglist ] && exit 1
+  [ ! -f $TMPDIR/pkglist ] && return 1
   rm $TMPDIR/pkglist &>/dev/null
 }
 
@@ -2337,10 +2437,22 @@ list_build_scripts(){             # list available build scripts  ($1 is optiona
   # check which BUILDTOOL we are using and list its build scripts
   case $BUILDTOOL in
     petbuild)
-      echo "$(LANG=C ls -R -1 /usr/share/petbuild/ 2>/dev/null | grep -v ^'/' | grep -v ^$ | grep '.petbuild' | sed -e "s/.petbuild$//g" | sort | $FILTER)" | grep -v ^$
+      find /usr/share/petbuild/ -type f -name "*.petbuild" \
+        | grep -vE '^/$|^$'                                \
+        | sed                                              \
+          -e 's#.*/##g'                                    \
+          -e "s/.petbuild$//g"                             \
+        | sort -u                                          \
+        | $FILTER
     ;;
     buildpet)
-      echo "$(LANG=C ls -R -1 /usr/share/buildpet/ 2>/dev/null  | grep -v ^'/' | grep -v ^$ | grep -v 'buildpet.profile' | sed -e "s/.bp$//g" | sort | $FILTER)" | grep -v ^$
+      find /usr/share/buildpet/ -type f -name "*.petbuild" \
+        | grep -vE '^/$|^$|buildpet.profile'               \
+        | sed                                              \
+          -e 's#.*/##g'                                    \
+          -e "s/.bp$//g"                                   \
+        | sort -u                                          \
+        | $FILTER
     ;;
     src2pkg)
       echo "Use: src2pkg FILE|URL or src2pkg -h"
@@ -2360,6 +2472,7 @@ list_downloaded_pkgs(){           # list packages downloaded in WORKDIR ($1 is o
 
   . ${PKGRC}
 
+  (
   cd "$WORKDIR" || { error "Cant cd into $WORKDIR"; exit 3; }
 
   local pkg
@@ -2371,7 +2484,7 @@ list_downloaded_pkgs(){           # list packages downloaded in WORKDIR ($1 is o
     find "${WORKDIR}" -maxdepth 1 -type f | sed -e "s#${WORKDIR}##g" -e "s#^/##g" | grep -v ^'.pkg' | sort \
       | while read pkg # but go through each and only print it if a valid pkg
       do
-        [ "`is_local_pkg "$pkg"`" = true ] && echo $pkg || continue
+        [ "$(is_local_pkg "$pkg")" = true ] && echo "$pkg"
       done
 
     return 0
@@ -2386,7 +2499,7 @@ list_downloaded_pkgs(){           # list packages downloaded in WORKDIR ($1 is o
         find "${WORKDIR}" -maxdepth 1 -type f | sed -e "s#${WORKDIR}##g" -e "s#^/##g" | grep -v ^'.pkg'|grep ^"$x" | sort \
           | while read pkg # but go through each and only print it if a valid pkg
           do
-            [ "`is_local_pkg "$pkg"`" = true ] && echo $pkg || continue
+            [ "$(is_local_pkg "$pkg")" = true ] && echo "$pkg"
           done
 
         return 0
@@ -2394,7 +2507,8 @@ list_downloaded_pkgs(){           # list packages downloaded in WORKDIR ($1 is o
     done
   fi
 
-  cd -
+  cd - || exit 1
+  )
 }
 
 
@@ -2406,7 +2520,7 @@ list_installed_pkgs(){            # list user installed packages ($1 is optional
 
   user_pkgs_list=${HOME}/.packages/user-installed-packages
 
-  if [ "$HIDE_BUILTINS" != true -a -f ${HOME}/.packages/devx-only-installed-packages ];then
+  if [ "$HIDE_BUILTINS" != true ] && [ -f ${HOME}/.packages/devx-only-installed-packages ];then
     devx_pkgs_list=${HOME}/.packages/devx-only-installed-packages
   fi
 
@@ -2430,7 +2544,7 @@ list_builtin_pkgs(){              # lists builtin packages FUNCLIST
   builtins_repo=${HOME}/.packages/woof-installed-packages
 
   # search builtins (woof-installed) repo file only .. $1 is the optional pkg filter.. take field1, remove empty lines, remove dashes, remove Pkg from pkg list too
-  cut -f1 -d'|' $builtins_repo | grep "^$1" | grep -v ^\$  | grep -v "\-$" | grep -v ^pkg\- | sort
+  cut -f1 -d'|' $builtins_repo | grep "^$1" | grep -v ^\$  | grep -v "\-$" | grep -v "^pkg-" | sort -u
 }
 
 
@@ -2442,14 +2556,14 @@ search_pkgs(){                    # given $1, searches current repo, shows name 
   local search
 
   # convert "foo[ -_]bar" into "foo.*bar"
-  search=`echo "$1" | sed -e 's| |.*|g' -e 's|-|.*|g' -e 's|_|.*|g'`
+  search=$(echo "$1" | sed -e 's| |.*|g' -e 's|-|.*|g' -e 's|_|.*|g')
 
   # convert repo file to nice columnised output, use cat|grep so empty searches return all results
-  cat ${HOME}/.packages/${REPOFILE} 2>/dev/null | grep -i "$search" | while read repo_line;
+  grep -i "$search" ${HOME}/.packages/${REPOFILE} 2>/dev/null | while read repo_line;
   do
-    name=`echo  "$repo_line"|cut -f2  -d'|'`
-    desc="`echo "$repo_line"|cut -f10 -d'|' | head -c 57`"
-    descfull="`echo "$repo_line"|cut -f10 -d'|'`"
+    name=$(echo  "$repo_line"|cut -f2  -d'|')
+    descfull="$(echo "$repo_line"|cut -f10 -d'|')"
+    desc="$(echo "$descfull"| head -c 57)"
     [ "$desc" != "$descfull" ] && desc="${desc}.."
     printf "%-20s" "$name" " ${desc:-No description}"
     echo
@@ -2458,19 +2572,18 @@ search_pkgs(){                    # given $1, searches current repo, shows name 
 
 
 search_fast(){                    # given $1, searches current repo, show pkg names only, case sensitive FUNCLIST
-  local RES
   local search
 
   # convert "foo[ -_]bar" into "foo.*bar"
-  search=`echo "$1" | sed -e 's| |.*|g' -e 's|-|.*|g' -e 's|_|.*|g'`
+  search=$(echo "$1" | sed -e 's| |.*|g' -e 's|-|.*|g' -e 's|_|.*|g')
 
   # get matching pkgs
-  RES="`LANG=C grep "$search" ${HOME}/.packages/${REPOFILE} 2>/dev/null | cut -f1 -d'|'`"
-  # error if no result
-  [ ! "$RES" ] && exit 1
+  LANG=C grep -i "$search" ${HOME}/.packages/${REPOFILE} 2>/dev/null \
+    | cut -f1 -d'|' \
+    | sort -u -t $separator -k1,1df -k2gr -k3gr -k4gr > $TMPDIR/pkglist
 
-  # put results into file
-  echo "$RES" > $TMPDIR/pkglist
+  # error if no result
+  [ ! -s "$TMPDIR/pkglist" ] && return 1
 
   # hide built-in, devx and user installed packages
   if [ $HIDE_INSTALLED = true ];then
@@ -2479,13 +2592,14 @@ search_fast(){                    # given $1, searches current repo, show pkg na
 
   hide_blacklisted_pkgs_from_search_results
 
-  # now build the search results
-  RES="`grep -v "^\$" $TMPDIR/pkglist 2>/dev/null | sort --field-separator='-' -k1,1df -k2gr -k3gr -k4gr | uniq`"
-  rm $TMPDIR/pkglist &>/dev/null
+  # error if no result
+  [ ! -s "$TMPDIR/pkglist" ] && return 1
 
-  #finshed making search results, print results
-  [ "$RES" = "" ] && exit 1
-  echo "$RES"
+  # now show the search results
+  grep -v ^$ $TMPDIR/pkglist
+
+  # clean up
+  rm $TMPDIR/pkglist 2>/dev/null
 }
 
 
@@ -2497,17 +2611,17 @@ search_all_pkgs(){                # given $1, search all repos, show name and de
   local search
 
   # convert "foo[ -_]bar" into "foo.*bar"
-  search=`echo "$1" | sed -e 's| |.*|g' -e 's|-|.*|g' -e 's|_|.*|g'`
+  search=$(echo "$1" | sed -e 's| |.*|g' -e 's|-|.*|g' -e 's|_|.*|g')
 
-  for repo_file in `repo_file_list`
+  for repo_file in $(repo_file_list)
   do #090817
     # convert repo file to nice columnised output
-    cat ${HOME}/.packages/${repo_file} 2>/dev/null | grep -i "$search" | while read repo_line;
+    grep -i "$search" ${HOME}/.packages/${repo_file} 2>/dev/null | while read repo_line;
     do
     # get details from repo
-    name=`echo  "$repo_line"|cut -f2  -d'|'`
-    desc="`echo "$repo_line"|cut -f10 -d'|' | head -c 57`"
-    descfull="`echo "$repo_line"|cut -f10 -d'|'`"
+    name=$(echo  "$repo_line"|cut -f2  -d'|')
+    descfull="$(echo "$repo_line"|cut -f10 -d'|')"
+    desc="$(echo "$descfull" | head -c 57)"
     [ "$desc" != "$descfull" ] && desc="${desc}.."
     # remove spaces and comments (slackware-extra repo has some dodgy entries.. dogy names, descriptions with comments, etc)
     name="${name// /}"
@@ -2518,36 +2632,28 @@ search_all_pkgs(){                # given $1, search all repos, show name and de
     echo
     done
   done
-
 }
 
 
 search_all_fast(){                # given $1, search all repos, show pkg names only, case sensitive FUNCLIST
-  local RES
   local search
 
   # convert "foo[ -_]bar" into "foo.*bar"
-  search=`echo "$1" | sed -e 's| |.*|g' -e 's|-|.*|g' -e 's|_|.*|g'`
+  search=$(echo "$1" | sed -e 's| |.*|g' -e 's|-|.*|g' -e 's|_|.*|g')
 
   #if bleeding edge enabled, combine into 1 list, so
   # that `pkg -g` etc return most recent from ALL repos
   rm $TMPDIR/pkglist &>/dev/null
-  if [ "$BLEDGE" = "yes" ];then
-    RES=''
-    for RF in `repo_file_list`
-    do #090817
-      cat ${HOME}/.packages/${RF} 2>/dev/null | grep -i "$search" | cut -f1 -d'|' | sort --field-separator='-' -k1,1df -k2gr -k3gr -k4gr | uniq | sed -e '/^$/d' >> $TMPDIR/pkglist
-    done
 
-  else
-    # if bleeding edge disabled, output the list repo by repo, in #
-    # the fallback order, current repo first (that order is set in update_sources)
-    for RF in `repo_file_list`
-    do #090817
-      cat ${HOME}/.packages/${RF} 2>/dev/null | grep -i "$search"| cut -f1 -d'|' | sort --field-separator='-' -k1,1df -k2gr -k3gr -k4gr | uniq | sed -e '/^$/d' >> $TMPDIR/pkglist
-    done
+  # output the list repo by repo, in the fallback order,
+  # current repo first (that order is set in update_sources)
+  for RF in $(repo_file_list)
+  do
+    grep -i "$search" ${HOME}/.packages/${RF} 2>/dev/null | cut -f1 -d'|' | sort -u -t $separator -k1,1df -k2gr -k3gr -k4gr | sed -e '/^$/d' >> $TMPDIR/pkglist
+  done
 
-  fi
+  # error if no result
+  [ ! -s "$TMPDIR/pkglist" ] && return 1
 
   #100817 hide built-in, devx and user installed packages
   if [ $HIDE_INSTALLED = true ];then
@@ -2556,196 +2662,103 @@ search_all_fast(){                # given $1, search all repos, show pkg names o
 
   hide_blacklisted_pkgs_from_search_results
 
-  # now build the search results
-  RES="`grep -v "^\$" $TMPDIR/pkglist 2>/dev/null | sort --field-separator='-' -k1,1df -k2gr -k3gr -k4gr | uniq`"
+  # error if no result
+  [ ! -s "$TMPDIR/pkglist" ] && return 1
+
+  # if bleeding edge, re-order the whole list, so output no longer
+  # repo by repo, but newest packages at the top
+  if [ "$BLEDGE" = "yes" ];then
+    sort -u -t $separator -k1,1df -k2gr -k3gr -k4gr "$TMPDIR/pkglist" > "$TMPDIR/pkglist_sorted"
+    mv "$TMPDIR/pkglist_sorted" "$TMPDIR/pkglist"
+  fi
+
+  # now print the search results
+  grep -v "^\$" $TMPDIR/pkglist 2>/dev/null
+
+  # clean up
   rm $TMPDIR/pkglist &>/dev/null
-
-  #finshed making search results, print results
-  [ "$RES" = "" ] && exit 1
-
-  echo "$RES"
 }
 
 
 which_repo(){                     # list repo of given package ($1) FUNCLIST
 
   # if no valid options, quit
-  [ ! "$1" -o "$1" = "-" -o "$1" = " " ] && print_usage which-repo && exit 1
+  [ ! "$1" ] || [ "$1" = "-" ] || [ "$1" = " " ] && print_usage which-repo && exit 1
 
-  . ${PKGRC}
+  . "${PKGRC}"
 
   local PKGNAME=''
   local PKGNAME_ONLY=''
-  local pkg_ext=''
   local repo_file=''
   local repo_name=''
   local pkg_list=''
 
-  PKGNAME=`get_pkg_name "$1"`
-  PKGNAME_ONLY=`get_pkg_name_only "$1"`
-  pkg_ext=`get_pkg_ext "$PKGNAME"`
+  PKGNAME=$(get_pkg_name "$1")
+  repo_file="$(grep -l "^$PKGNAME|" ${HOME}/.packages/Packages-* | head -1)"
 
-  repo_file="`grep -l "|$PKGNAME.$pkg_ext|" ${HOME}/.packages/Packages-*`"
-  if [ "$repo_file" != '' ];then
-    # get the repo name
-    repo_name="`grep -m1 "$(basename $repo_file)|" ${HOME}/.pkg/sources | cut -f1 -d'|'`"
-    pkg_list="$PKGNAME $repo_name"
-  else
-
-    # for each repo
-    for repo_file in `repo_file_list`
-    do
-      # get the repo name
-      repo_name="`grep -m1 "$repo_file|" ${HOME}/.pkg/sources | cut -f1 -d'|'`"
-      # create the entries, example: "vlc slacko14.2"
-      # (each line shows a matching package, then a SPACE, then the name of repo the package lives in)
-      pkg_list="$pkg_list`LANG=C grep "$PKGNAME" ${HOME}/.packages/${repo_file} 2>/dev/null | grep -m1 "^$PKGNAME|" | cut -f1 -d'|' | tr '\n' '@' | sed -e "s#@# $repo_name\n#g"`"
-      [ "$pkg_list" = '' ] && pkg_list="$pkg_list`LANG=C grep "$PKGNAME" ${HOME}/.packages/${repo_file} 2>/dev/null | grep -m1 "|$PKGNAME.$EX|" | cut -f1 -d'|' | tr '\n' '@' | sed -e "s#@# $repo_name\n#g"`"
-      [ "$pkg_list" = '' ] && pkg_list="$pkg_list`LANG=C grep "$PKGNAME" ${HOME}/.packages/${repo_file} 2>/dev/null | grep -m1 "|$1.$EX|" | cut -f1 -d'|' | tr '\n' '@' | sed -e "s#@# $repo_name\n#g"`"
-      [ "$pkg_list" = '' ] && pkg_list="$pkg_list`LANG=C grep "$PKGNAME" ${HOME}/.packages/${repo_file} 2>/dev/null | grep -m1 "|$PKGNAME_ONLY|" | cut -f1 -d'|' | tr '\n' '@' | sed -e "s#@# $repo_name\n#g"`"
-      [ "$pkg_list" = '' ] && pkg_list="$pkg_list`LANG=C grep "$PKGNAME" ${HOME}/.packages/${repo_file} 2>/dev/null | grep -m1 "^$PKGNAME_ONLY|" | cut -f1 -d'|' | tr '\n' '@' | sed -e "s#@# $repo_name\n#g"`"
-      [ "$pkg_list" = '' ] && pkg_list="$pkg_list`LANG=C grep "$PKGNAME" ${HOME}/.packages/${repo_file} 2>/dev/null | grep -m1 "|$1|" | cut -f1 -d'|' | tr '\n' '@' | sed -e "s#@# $repo_name\n#g"`"
-      [ "$pkg_list" = '' ] && pkg_list="$pkg_list`LANG=C grep "$PKGNAME" ${HOME}/.packages/${repo_file} 2>/dev/null | grep -m1 "^$1|" | cut -f1 -d'|' | tr '\n' '@' | sed -e "s#@# $repo_name\n#g"`"
-    done
+  if [ -z "$repo_file" ];then
+    PKGFILENAME=$(get_pkg_filename "$PKGNAME")
+    repo_file="$(grep -l "|$PKGFILENAME|" ${HOME}/.packages/Packages-* | head -1)"
   fi
 
-  # show results
-  LANG=C echo -e "$pkg_list" | sed -e '/^$/d' | uniq
+  if [ -z "$repo_file" ];then
+    repo_file="$(grep -l "^$PKGNAME|" ${HOME}/.packages/user-installed* | head -1)"
+    [ ! -z "$repo_file" ] && return 1
+  fi
+
+  if [ -z "$repo_file" ];then
+    repo_file="$(grep -l "|$PKGNAME_ONLY|" ${HOME}/.packages/Packages-* | head -1)"
+  fi
+
+  if [ ! -z "$repo_file" ];then
+    # get the repo name
+    repo_name="$(grep -m1 "|$(basename $repo_file)|" ${HOME}/.pkg/sources-all | cut -f1 -d'|')"
+    pkg_list="$PKGNAME $repo_name"
+    # show results
+    echo -e "$pkg_list" | sed -e '/^ $/d' | sort -u
+    return 0
+  fi
+
+  return 1
 }
 
 
 which_pkg(){                      # find out which pkg FILE ($1) comes from FUNCLIST
 
   # exit if no valid opts
-  [ ! "$1" -o "$1" = '-' -o "$1" = '' ] && print_usage which && exit 1
+  [ ! "$1" ] || [ "$1" = '-' ] || [ "$1" = '' ] && print_usage which && exit 1
 
   local PKGNAME=''
-  local PKG_FILE_LIST=''
   local FILENAME=''
-  local FILENAME_ONLY=''
-  local DIRNAME=''
-  local builtins_without_busybox="`find ${HOME}/.packages/builtin_files/* -maxdepth 1 -type f | grep -v "/busybox"`"
+  local cmd=''
 
   # get user input
-  FILENAME="`basename "$1"`"
-  FILENAME_ONLY="$FILENAME"
-  DIRNAME="`dirname "$1"`"
+  FILENAME="$1"
 
   # if we don't have a file, the user probably gave a command,
   # so lets check see
-  if [ ! -f "$1" ];then
+  if [ ! -f "$FILENAME" ];then
     # if we get a command, then that is our FILENAME
-    cmd=`which "$1"`
+    cmd=$(which "$FILENAME")
     # if $cmd found, set FILENAME to $cmd (FILENAME now includes full path)
-    [ "$cmd" != '' ] && FILENAME=$cmd && FILENAME_ONLY=`basename "$FILENAME"`
+    [ "$cmd" != '' ] && FILENAME=$cmd
   fi
 
-  # dont use relative paths
-  [ "`echo "$DIRNAME" | grep "^\."`" != '' ] && DIRNAME=''
+  # check if the given file or cmd is from a built in package 
+  pkgfile="$(grep -l "^$FILENAME\$" ~/.packages/builtin_files/* | head -1)"
+  [ -f "$pkgfile" ] && PKGNAME="$(get_pkg_name "$(basename $pkgfile 2>/dev/null)")"
 
-  # try user installed pkgs contents of $HOME/.packages/*.files
-
-  # try '$dir/$file', returns filename (no path) of matching *.files
-  [ "$PKG_FILE_LIST" = '' ] && PKG_FILE_LIST="`grep -l "$DIRNAME/$FILENAME\$"  ${HOME}/.packages/*.files 2>/dev/null| sed "s#$HOME/.packages/##g" 2>/dev/null`"
-
-  # try '$dir/$file_*' if needed
-  [ "$PKG_FILE_LIST" = '' ] && PKG_FILE_LIST="`grep -l "$DIRNAME/${FILENAME}_" ${HOME}/.packages/*.files 2>/dev/null| sed "s#$HOME/.packages/##g" 2>/dev/null`"
-
-  # try '$dir/$file-*' if needed
-  [ "$PKG_FILE_LIST" = '' ] && PKG_FILE_LIST="`grep -l "$DIRNAME/${FILENAME}\-" ${HOME}/.packages/*.files 2>/dev/null| sed "s#$HOME/.packages/##g" 2>/dev/null`"
-
-  # if we found a package, set the package name to the name of the *.files file that we got
-  [ "$PKG_FILE_LIST" != '' ] && PKGNAME="`basename "$PKG_FILE_LIST" .files`"
-
-  # maybe we got nothing from *.files.. check builtins/$1* for ' $FILENAME_ONLY',
-  # returns PKGNAME of the matching builtin
-
-  # if needed, search inside builtin file lists (EXCEPT busybox) for ' $FILENAME_ONLY'
-  [ "$PKG_FILE_LIST" = '' ] && [ "$PKGNAME" = "" ] \
-    && PKGNAME="$(basename `grep -l "^ $FILENAME_ONLY\$" $builtins_without_busybox | sed "s#$HOME/.packages/builtin_files/##g"` 2>/dev/null)"
-
-  # if that didn't work, search inside builtin file lists of busybox for ' $FILENAME_ONLY'
-  [ "$PKG_FILE_LIST" = '' ] && [ "$PKGNAME" = "" ] \
-    && PKGNAME="$(basename `grep -l "^ $FILENAME_ONLY\$" ${HOME}/.packages/builtin_files/busybox | sed "s#$HOME/.packages/builtin_files/##g"` 2>/dev/null)"
-
-  # apps in ADRV sfs dont have their files listed in their $HOME/.packages/builtin_files/$pkgname.. so..
-
-
-  # now check pkg names (not pkg contents) of builtins (EXCEPT busybox) for '$file'.. cos maybe we didnt find the file inside the file lists
-  [ "$PKGNAME" = "" ] \
-    && PKGNAME="`echo "$builtins_without_busybox" | grep -m1 "^${FILENAME_ONLY}\$" | sed "s#$HOME/.packages/builtin_files/##g" 2>/dev/null`"
-
-  # now look for '$file' in user installed repo list
-  [ "$PKGNAME" = "" ] \
-    && PKGNAME="`cut -f1,2,8 -d'|' $HOME/.packages/user-installed-packages 2>/dev/null | sed -e "s/^/|/" -e "s/\$/|/" 2>/dev/null| grep -m1 "|$FILENAME_ONLY|" | cut -f2 -d'|'`"
-
-  # also look for '$file' in user/woof/devx installed repo list
-  [ "$PKGNAME" = "" ] \
-    && PKGNAME="`cut -f1,2,8 -d'|' $HOME/.packages/*-installed-packages 2>/dev/null | sed -e "s/^/|/" -e "s/\$/|/" 2>/dev/null | grep -m1 "|$FILENAME_ONLY|" | cut -f2 -d'|'`"
-
-
-  # we searched for an exact match in builtins, user installed, woof installed and devx pkgs, now try some fuzzier matches
-
-  # try /$file_* in builtins
-  [ "$PKGNAME" = "" ] \
-    && PKGNAME="$(basename `grep -l " ${FILENAME_ONLY}_" ${HOME}/.packages/builtin_files/* | sed "s#$HOME/.packages/builtin_files/##g"` 2>/dev/null)"
-
-  # try $file-* in builtins
-  [ "$PKGNAME" = "" ] \
-    && PKGNAME="$(basename `grep -l " ${FILENAME_ONLY}-" ${HOME}/.packages/builtin_files/* | sed "s#$HOME/.packages/builtin_files/##g"` 2>/dev/null)"
-
-  # try $file.* in builtins
-  [ "$PKGNAME" = "" ] \
-    && PKGNAME="$(basename `grep -l " ${FILENAME_ONLY}\." ${HOME}/.packages/builtin_files/* | sed "s#$HOME/.packages/builtin_files/##g"` 2>/dev/null)"
-
-  # try *file in builtin pkgs
-  [ "$PKGNAME" = "" ] \
-    && PKGNAME="$(basename `grep -l "${FILENAME_ONLY}"\$ ${HOME}/.packages/builtin_files/* | sed "s#$HOME/.packages/builtin_files/##g"` 2>/dev/null)"
-
-
-  # if we still didnt find it, look in user installed package lists, for FILENAME
-  [ "$PKGNAME" = "" ] \
-    && PKGNAME=`cut -f1,2,8 -d '|' ${HOME}/.packages/user-installed-packages \
-      | sed -e "s/^/|/" -e "s/\$/|/" 2>/dev/null \
-      | grep -m1 "|${FILENAME_ONLY}|" \
-      | cut -f2 -d'|'` 2>/dev/null
-
-  # if we still didnt find it, look in all installed package lists, for FILENAME
-  [ "$PKGNAME" = "" ] \
-    && PKGNAME=`cut -f1,2,8 -d '|' ${HOME}/.packages/*-installed-packages \
-      | sed -e "s/^/|/" -e "s/\$/|/" 2>/dev/null \
-      | grep -m1 "|${FILENAME_ONLY}|" \
-      | cut -f2 -d'|'` 2>/dev/null
-
-  # if we still didnt find it, look in all installed package lists, for *FILENAME
-  [ "$PKGNAME" = "" ] \
-    && PKGNAME=`cut -f1,2,8 -d '|' ${HOME}/.packages/*-installed-packages \
-      | sed -e "s/^/|/" -e "s/\$/|/" 2>/dev/null \
-      | grep -m1 "${FILENAME_ONLY}|" \
-      | cut -f2 -d'|'` 2>/dev/null
-
-  # if we still didnt find it, look in all installed package lists, for FILENAME*
-  [ "$PKGNAME" = "" ] \
-    && PKGNAME=`cut -f1,2,8 -d '|' ${HOME}/.packages/*-installed-packages \
-      | sed -e "s/^/|/" -e "s/\$/|/" \
-      | grep -m1 "|${FILENAME_ONLY}" \
-      | cut -f2 -d'|'` 2>/dev/null
-
-
-  # clean up
-  [ "$PKGNAME" = '.files' ] && PKGNAME=''
-  PKGNAME="`echo "$PKGNAME" | head -1`"
-
-  # now print pkgs which contain the given file ($1)
-  if [ "$PKGNAME" != "" ];then
-    echo "$PKGNAME"
-    return 0
-  else
-    echo "File '$FILENAME' not found in any installed or built-in pkgs."
-    exit 1
+  # check if the given file or cmd is from a user installed in package 
+  if [ -z "$PKGNAME" ];then
+    pkgfile="$(grep -l "^$FILENAME\$" ~/.packages/*.files | head -1)"
+    [ -f "$pkgfile" ] && PKGNAME="$(get_pkg_name "$(basename $pkgfile 2>/dev/null | sed 's/\.files//g')")"
   fi
+
+  [ ! -z "$PKGNAME" ] && echo "$PKGNAME" && return 0
+  
+  echo "File '$FILENAME' not found in any installed or built-in pkgs."
+  return 1
 }
-
 
 
 # pkg info funcs
@@ -2753,10 +2766,10 @@ which_pkg(){                      # find out which pkg FILE ($1) comes from FUNC
 pkg_contents(){                   # list package ($1) contents FUNCLIST
 
   # if no valid options, quit
-  [ ! "$1" -o "$1" = "-" -o "$1" = " " ] && print_usage contents && exit 1
+  [ ! "$1" ] || [ "$1" = "-" ] || [ "$1" = " " ] && print_usage contents && exit 1
 
   # get settings
-  . ${PKGRC}
+  . "${PKGRC}"
 
   local PKGFILE
   local ext
@@ -2765,31 +2778,33 @@ pkg_contents(){                   # list package ($1) contents FUNCLIST
   local pkg_is_local_file
   local pkg_is_builtin
   local pkg_is_installed
-  local PKGFLIST=''
 
   # get pkg extension
-  ext=`get_pkg_ext "$1"`
-
-  # get pkg name (includes version), but no extension or path
+  ext=$(get_pkg_ext "${1:-$EX}")
   PKGNAME="$(basename "$1" .$ext)"
-  PKGNAME=`get_pkg_name "$PKGNAME"`
+  PKGNAME=$(get_pkg_name "$PKGNAME")
+  PKGFILE="$(get_pkg_filename "$1")"
+  pkg_is_installed=$(HIDE_BUILTINS=true is_installed_pkg "$PKGNAME")
 
-  # get pkg name without version
-  PKGNAME_ONLY=`get_pkg_name_only "$PKGNAME"`
+  if [ "$pkg_is_installed" = true ] && [ -f "$HOME/.packages/${PKGFILE//.$ext/}.files" ];then
+    cat "$HOME/.packages/${PKGFILE//.$ext/}.files"
+    return 0
+  fi
 
-  pkg_is_local_file=`is_local_pkg "$1"`
-  pkg_is_builtin=`is_builtin_pkg "$PKGNAME_ONLY"`
-  pkg_is_installed=`is_installed_pkg "$PKGNAME_ONLY"`
+  if [ "$pkg_is_installed" = true ];then
+    PKGNAME=$(list_installed_ $PKGNAME | head -1)
+    cat "$HOME/.packages/${PKGNAME}.files"
+    return 0
+  fi
 
-  # now we check various ways to find out the contents of
-  # a pkg (either by *.files, user installed, woof, builtin, etc)
-
-  [ "$pkg_is_local_file" = true ] && PKGFILE="$1"
+  if [ "$pkg_is_installed" = true ] && [ -f "$HOME/.packages/${PKGNAME}.files" ];then
+    cat "$HOME/.packages/${PKGNAME}.files"
+    return 0
+  fi
 
   # try a file in the current dir if needed
-  [ ! -f "$PKGFILE" ] && PKGFILE="${CURDIR}/${PKGNAME}.$ext"
-  # check $WORKDIR if needed
-  [ ! -f "$PKGFILE" ] && PKGFILE="${WORKDIR}/${PKGNAME}.$ext"
+  [ ! -f "${PKGFILE}.${ext}" ] && PKGFILE="$(find "$CURDIR" -type f -name "${PKGFILE}.${ext}")"
+  [ ! -f "${PKGFILE}.${ext}" ] && PKGFILE="$(find "$WORKDIR" -type f -name "${PKGFILE}.${ext}")"
 
   # if the pkg is a local file
   if [ -f "$PKGFILE" ];then
@@ -2806,7 +2821,7 @@ pkg_contents(){                   # list package ($1) contents FUNCLIST
       # (shown if listing *some* pkg file contents)
       tar -tf "$PKGFILE" 2>/dev/null \
         | sed -e "s#^./${PKGNAME}/#/#g" -e "s#^${PKGNAME}/#/#g" -e "s#^./##g" 2>/dev/null \
-        | grep -v ^$ 2>/dev/null 2>/dev/null \
+        | grep -v ^$ 2>/dev/null \
         | grep -v "^/$"
     ;;
     rpm)
@@ -2816,129 +2831,57 @@ pkg_contents(){                   # list package ($1) contents FUNCLIST
     exit $?
   fi
 
-  # if we are here, the pkg is not a downloaded pkg, so we build a
-  # list of files by checking  *.files, woof, builtins ..
+  # if we are here, the pkg is not a user installed or downloaded pkg..
+  # but it might be a "builtin" package..
 
-  # check if we need to (and can) get our pkg contents from builtins/PKGNAME
-  local  need_to_check_builtins=`echo "$PKG_FLIST" | grep -m1 'packages/builtin_files/'`
+  # get pkg name without version
+  PKGNAME_ONLY=$(get_pkg_name_only "$PKGNAME")
 
   # if the pkg is a builtin, we will re-format the output of LIST to match the others (full paths on each line)
-  if [ "$need_to_check_builtins" != '' -a "$pkg_is_builtin" = true ];then
+  if [ -f "$HOME/.packages/builtin_files/$PKGNAME_ONLY" ];then
 
     # reset the list of pkg files, we will re-build it
     rm $TMPDIR/pkg_file_list 2>/dev/null
 
-    # first we get the package contents from $HOME/.packages/builtin_files/$PKGNAME_ONLY
-    cat "$PKG_FLIST" 2>/dev/null | while read line
+    # builtin files may not list full paths, parse it if needed
+    cat "$HOME/.packages/builtin_files/$PKGNAME_ONLY" 2>/dev/null | while read line
     do
-      # parse it, so we get a full path to file on each line
-      if [ "`echo "$line" | grep '^/'`" != '' ];then
-        # set the dir to use in our file list
-        dir="$line"
-      else
-        # keep previous dir
+      if [ "$(echo "$line" | grep ' ')" != '' ];then
+        # parse it, so we get a full path to file on each line
         dir="$dir"
+        line_to_add="$dir/$(echo "$line" | cut -f2 -d' ')"
+      else
+        dir="$line"
+        line_to_add="$line"
       fi
 
-      # create our new line (a full file path) to $LIST
-      line_to_add="$dir/`echo "$line" | cut -f2 -d' '`"
-
       # if only a dir, skip it
-      [ "$line" = "$dir" ] && continue
+      [ -d "$line_to_add" ] && continue
 
       # if its already added, skip it
-      [ "`grep -m1 "$line_to_add" ${TMPDIR}/pkg_file_list 2>/dev/null `" != '' ] && continue
+      grep -q -m1 "$line_to_add" ${TMPDIR}/pkg_file_list 2>/dev/null && continue
 
       # if its not a file on the system (it should be), skip it
-      [ ! -f "$line_to_add" ] && continue
+      [ ! -e "$line_to_add" ] && continue
 
       # all should be ok, add the line to our list
       echo "$line_to_add" >> $TMPDIR/pkg_file_list
-
     done
 
-    # now get our pkg contents list, it might have been re-formatted (if a builtin)
-    PKG_FLIST="`cat ${TMPDIR}/pkg_file_list 2>/dev/null`"
-
-    # last resort, if we lost our file list or still dont have, try the basics again
-    [ "$PKG_FLIST" = '' ] && PKG_FLIST="`find $HOME/.packages/ -maxdepth 1 -type f -name "${PKGNAME}*.files" 2>/dev/null`"
-
-    # clean up the list a bit
-    [ "$PKG_FLIST" != '' ] && PKG_FLIST="`echo "$PKG_FLIST" | grep -v ' ' | grep -v "^\$" | sort -u`"
+    # print formatted contents
+    cat ${TMPDIR}/pkg_file_list 2>/dev/null
 
     # and clean up the tmp files
     rm ${TMPDIR}/pkg_file_list 2>/dev/null
+    exit 0
   fi
 
-  # try PKGNAME_ONLY.files (exact match)
-  PKG_FLIST="`find $HOME/.packages/ -maxdepth 1 -type f -name "${PKGNAME_ONLY}.files" 2>/dev/null`"
-
-  # try finding PKGNAME.files (exact match)
-  [ ! -f "$PKG_FLIST" ] && PKG_FLIST="`find $HOME/.packages/ -maxdepth 1 -type f -name "${PKGNAME}.files" 2>/dev/null`"
-
-  # try the builtins files (exact match)
-  [ ! -f "$PKG_FLIST" ] && PKG_FLIST="`find $HOME/.packages/builtin_files/ -maxdepth 1 -type f -name "$PKGNAME_ONLY"`"
-
-  # try PKGNAME (exact match) in user installed pkgs
-  [ ! -f "$PKG_FLIST" ] && PKG_FLIST="$HOME/.packages/`cut -f1 -d'|' $HOME/.packages/user-installed-packages | grep -m1 ^"$PKGNAME\$" 2>/dev/null`.files"
-
-  # try PKGNAME (exact match) in all installed pkgs
-  [ ! -f "$PKG_FLIST" ] && PKG_FLIST="$HOME/.packages/`cut -f1 -d'|' $HOME/.packages/*-installed-packages | grep -m1 ^"$PKGNAME\$" 2>/dev/null`.files"
-
-  # try PKGNAME_ONLY (exact match) in all installed pkgs
-  [ ! -f "$PKG_FLIST" ] && PKG_FLIST="$HOME/.packages/`cut -f2 -d'|' $HOME/.packages/*-installed-packages | grep -m1 ^"$PKGNAME_ONLY\$" 2>/dev/null`.files"
-
-
-  # no exact matches found, try fuzzy searches..
-
-  # try PKGNAME*.files
-  [ ! -f "$PKG_FLIST" ] && PKG_FLIST="`find $HOME/.packages/ -maxdepth 1 -type f -name "/${PKGNAME}*.files"  2>/dev/null`"
-
-  # try finding *PKGNAME.files
-  [ ! -f "$PKG_FLIST" ] && PKG_FLIST="`find $HOME/.packages/ -maxdepth 1 -type f -name "*${PKGNAME}.files" 2>/dev/null`"
-
-  # try ^PKGNAME_ONLY[_-] in user installed pkgs
-  [ ! -f "$PKG_FLIST" ] && PKG_FLIST="$HOME/.packages/`cut -f1 -d'|' $HOME/.packages/user-installed-packages | grep -Em1 "^$PKGNAME_ONLY[_-]" 2>/dev/null`.files"
-
-  # try PKGNAME_ONLY* in user installed pkgs only
-  [ ! -f "$PKG_FLIST" ] && PKG_FLIST="$HOME/.packages/`cut -f1 -d'|' $HOME/.packages/user-installed-packages | grep -m1 ^"$PKGNAME_ONLY" 2>/dev/null`.files"
-
-  # try PKGNAME_ONLY-* (any installed pkgs)
-  [ ! -f "$PKG_FLIST" ] && PKG_FLIST="$HOME/.packages/`cut -f1 -d'|' $HOME/.packages/*-installed-packages | grep -Em1 ^"${PKGNAME_ONLY}[_-]" 2>/dev/null`.files"
-
-  # try PKGNAME_ONLY* (any installed pkgs)
-  [ ! -f "$PKG_FLIST" ] && PKG_FLIST="$HOME/.packages/`cut -f1 -d'|' $HOME/.packages/*-installed-packages | grep -m1 ^"$PKGNAME_ONLY" 2>/dev/null`.files"
-
-  # try PKGNAME_ONLY*.files
-  [ ! -f "$PKG_FLIST" ] && PKG_FLIST="`find $HOME/.packages/ -maxdepth 1 -type f -name "/${PKGNAME_ONLY}*.files"  2>/dev/null`"
-
-
-
-  #if we found a list of files
-  if [ "$PKG_FLIST" != "" ];then
-
-    print_cmd=echo
-    # PKG_FLIST just might contain a path to the pkg contents
-    # themselves (a *.files, or a file in builtin_files/*).. so if
-    # its a file path, we will cat it, if not, its the pkg contents
-    # themselves, we echo it
-    if [ "`echo "$PKG_FLIST" | grep -m1 '/builtin_files/'`" != '' -o "`echo "$PKG_FLIST" | grep -m1 "packages/$PKGNAME"`" != '' ];then
-      print_cmd=cat
-    fi
-
-    $print_cmd "$PKG_FLIST" | grep -v "^/$" 2>/dev/null
-
-  else # if no files found
-    if [ "$PKGNAME" != '' ];then
-      INST_CHECK="`is_installed_pkg $PKGNAME 2>/dev/null`"
-      if [ "$INST_CHECK" != true -o "$pkg_is_local_file" = false ];then
-        error "Package must be installed, downloaded or built-in."
-      else
-        error "Could not get package contents, unable to get file list."
-      fi
-    else
-      error "Could not get name of package."
-    fi
+  # if no files found
+  INST_CHECK="$(is_installed_pkg $PKGNAME 2>/dev/null)"
+  if [ "$INST_CHECK" != true ] || [ "$pkg_is_local_file" = false ];then
+    error "Package must be installed, downloaded or built-in."
+  else
+    error "Could not get package contents, unable to get file list."
   fi
 }
 
@@ -2946,28 +2889,28 @@ pkg_contents(){                   # list package ($1) contents FUNCLIST
 pkg_entry(){                      # show pkg ($1) repo entry, each field on a new line FUNCLIST
 
   # exit if no valid opts
-  [ ! "$1" -o "$1" = '-' ] && print_usage pkg-entry && exit 1
+  [ ! "$1" ] || [ "$1" = '-' ] && print_usage pkg-entry && exit 1
 
   local EX
   local PKGNAME
   local PKGNAME_ONLY
 
   # get pkg extension
-  EX=`get_pkg_ext "$1"`
+  EX=$(get_pkg_ext "$1")
 
   # get pkg name with version, but no extension or path
   PKGNAME="$(basename "$1" .$EX)"
 
   # dont rely on the string the user gave us, try to get the exact match
-  PKGNAME=`get_pkg_name "$PKGNAME"`
-  PKGNAME_ONLY=`get_pkg_name_only "$PKGNAME"`
+  PKGNAME=$(get_pkg_name "$PKGNAME")
+  PKGNAME_ONLY=$(get_pkg_name_only "$PKGNAME")
 
-  PKG_ENTRY="`cat ${HOME}/.packages/Packages-* | grep -m1 "|$PKGNAME|"`"
-  [ "$PKG_ENTRY" = '' ] && PKG_ENTRY="`cat ${HOME}/.packages/Packages-* | grep -m1 "^$PKGNAME|"`"
-  [ "$PKG_ENTRY" = '' ] && PKG_ENTRY="`cat ${HOME}/.packages/Packages-* | grep -m1 "|$PKGNAME_ONLY|"`"
+  PKG_ENTRY="$(cat ${HOME}/.packages/Packages-* | grep -m1 "|$PKGNAME|")"
+  [ "$PKG_ENTRY" = '' ] && PKG_ENTRY="$(cat ${HOME}/.packages/Packages-* | grep -m1 "^$PKGNAME|")"
+  [ "$PKG_ENTRY" = '' ] && PKG_ENTRY="$(cat ${HOME}/.packages/Packages-* | grep -m1 "|$PKGNAME_ONLY|")"
   if [ "$PKG_ENTRY" = '' ];then
-    echo "$1 not found in $REPOFILE"
-    exit 1
+    echo "'$1' not found in $REPOFILE"
+    return 1
   else
     echo "$PKG_ENTRY"
   fi
@@ -2978,10 +2921,10 @@ pkg_entry(){                      # show pkg ($1) repo entry, each field on a ne
 pkg_status(){                     # print package ($1) name, status, deps, etc FUNCLIST
 
   # exit if no valid options
-  [ ! "$1" -o "$1" = "-" ] && print_usage pkg-status && exit 1
+  [ ! "$1" ] || [ "$1" = "-" ] && print_usage pkg-status && exit 1
 
   # get current repo name
-  . ${PKGRC}
+  . "${PKGRC}"
 
   local EX
   local PKGNAME=''
@@ -2992,127 +2935,137 @@ pkg_status(){                     # print package ($1) name, status, deps, etc F
   local pkg_found=false
   local pkg_repo=''
   local pkg_repo_file=''
-  local prev_repo=${REPONAME}
+  local prev_repo="${REPONAME}"
 
   # get pkg extension
-  EX=`get_pkg_ext "$1"`
-
-  # get pkg name with version, but no extension or path
-  PKGNAME="$(basename "$1" .$EX)"
+  EX=$(get_pkg_ext "${1:-$EX}")
 
   # dont rely on the string the user gave us, try to get the exact match
-  PKGNAME=`get_pkg_name "$PKGNAME"`
+  PKGNAME=$(get_pkg_name "$1")
 
   # get pkg name without version
-  PKGNAME_ONLY=`get_pkg_name_only "$PKGNAME"`
+  PKGNAME_ONLY=$(get_pkg_name_only "$PKGNAME")
 
   [ "$PKGNAME" = '' ] && error "Can't find $1" && exit 1
 
   # get install status of pkg (installed or not)
-  [ "`is_installed_pkg $PKGNAME`" = true ] && install_status="installed" || install_status="not installed"
+  [ "$(is_installed_pkg $PKGNAME)" = true ] && install_status="installed" || install_status="not installed"
 
   # if pkg is installed, find out from where
   if [ "$install_status" = "installed" ];then
 
-    # check user installed pkgs for $PKGNAME
-    pkg_found=`LANG=C is_usr_pkg "${PKGNAME}"`
-    [ "$pkg_found" = true ] && install_status="installed (user)"
-
-    # if pkg not found yet, check if pkg is from the devx
-    if [ -f ${HOME}/.packages/devx-only-installed-packages -a "$pkg_found" = false ];then
-      pkg_found=`LANG=C is_devx_pkg "${PKGNAME}"`
-      [ "$pkg_found" = true ] && install_status="installed (in devx)"
-    fi
-
     # check builtins for PKGNAME_ONLY, if it exists, its a builtin pkg
-    if [ -d ${HOME}/.packages/builtin_files/ -a "$pkg_found" = false ];then
-      pkg_found=`LANG=C is_builtin_pkg "${PKGNAME_ONLY}"`
+    if [ -d ${HOME}/.packages/builtin_files/ ] && [ "$pkg_found" = false ];then
+      pkg_found=$(LANG=C is_builtin_pkg "${PKGNAME_ONLY}")
       [ "$pkg_found" = true ] && install_status="installed (builtin)"
     fi
 
-    # last gasp, if pkg not found yet, check if pkg if listed in layers-installed packages
-    if [ -f ${HOME}/.packages/layers-installed-packages -a "$pkg_found" = false ];then
-      pkg_found=`LANG=C grep -m1 "^${PKGNAME}|" ${HOME}/.packages/layers-installed-packages`
+    # check user installed pkgs for $PKGNAME
+    pkg_found=$(LANG=C is_usr_pkg "${PKGNAME}")
+    [ "$pkg_found" = true ] && install_status="installed (user)"
 
-      [ "$pkg_found" = '' ] && install_status="installed (layers)"
+    # if pkg not found yet, check if pkg is from the devx
+    if [ -f ${HOME}/.packages/devx-only-installed-packages ] && [ "$pkg_found" = false ];then
+      pkg_found=$(LANG=C is_devx_pkg "${PKGNAME}")
+      [ "$pkg_found" = true ] && install_status="installed (in devx)"
     fi
 
   fi
 
-  # get the repo of this pkg, if needed
-  [ "$pkg_repo" = '' ] && pkg_repo="`which_repo "$PKGNAME" 2>/dev/null | cut -f2 -d' '`"
-
-  # if we got a repo name, get the repo file
-  [ "$pkg_repo" != '' ] && pkg_repo_file="$(grep -m1 "^$pkg_repo|" ${HOME}/.pkg/sources | cut -f3 -d'|')"
-
   # if we have a repo to search for pkg info
-  if [ "$pkg_repo_file" != "" ];then
+  if [ "$(is_repo_pkg "$PKGNAME")" = true ];then
+
+    pkg_repo="$(which_repo "$PKGNAME")"
+    pkg_repo="${pkg_repo//* /}"
+    
+    pkg_repo_file="$(grep -m1 "^$pkg_repo|" $HOME/.pkg/sources-all | cut -f3 -d'|')"
 
     # get package description from its repo entry
-    pkg_desc="`LANG=C grep -m1 "|${PKGNAME_ONLY}|" $HOME/.packages/$pkg_repo_file 2>/dev/null| grep -m1 "$PKGNAME" | cut -f10 -d'|' | head -1`"
+    pkg_desc="$(LANG=C grep -m1 "|${PKGNAME_ONLY}|" $HOME/.packages/$pkg_repo_file 2>/dev/null \
+      | grep -m1 "$PKGNAME" \
+      | cut -f10 -d'|' \
+      | head -1)"
 
     if [ "$pkg_desc" = '' ];then
-      pkg_desc="`LANG=C grep -m1 "|${PKGNAME_ONLY}|" $HOME/.packages/Packages-* 2>/dev/null| grep -m1 "${PKGNAME}|" | cut -f10 -d'|' | head -1`"
+      pkg_desc="$(LANG=C grep -m1 "|${PKGNAME_ONLY}|" $HOME/.packages/Packages-* 2>/dev/null \
+        | grep -m1 "${PKGNAME}|" \
+        | cut -f10 -d'|' \
+        | head -1)"
     fi
 
     # get size of pkg
-    pkg_size=`LANG=C grep -m1 "|${PKGNAME_ONLY}|" $HOME/.packages/$pkg_repo_file 2>/dev/null | cut -f6 -d'|' | head -1`
+    pkg_size=$(LANG=C grep -m1 "|${PKGNAME_ONLY}|" $HOME/.packages/$pkg_repo_file 2>/dev/null | cut -f6 -d'|' | head -1)
 
     # add K to end of pkg_size, if not there already
     [ "$pkg_size" != '' ] && pkg_size="${pkg_size}K" && pkg_size="${pkg_size//KK/K}"
 
     # if called with -PS, we get the full info (where we sort deps missing or installed)
-    if [ "$FULL_PKG_STATUS" = true ];then
+    if [ "$FULL_PKG_STATUS" != true ];then
 
+      DEPS_ENTRY="Dependencies:   $(list_deps "$PKGNAME" 2>/dev/null)"
+
+    else
       # if pkg has many deps, checking the deps might take a while, print a 'please wait' msg
       please_wait=false
       # count deps of pkg
-      [ "`has_deps "$PKGNAME"`" = true ] && please_wait=true
+      [ "$(has_deps "$PKGNAME")" = true ] && please_wait=true
       [ "$please_wait" = true ] && echo -ne "Please wait.. Gathering dependency information.\n"
 
-      set_current_repo $pkg_repo 1>/dev/null
       # sort deps into 2 lists: missing deps and installed deps
       find_deps "$PKGNAME"
       set_current_repo $prev_repo 1>/dev/null
 
       # create a nicely formatted, coloured list of deps, green for installed, yellow for missing
-      INSTALLED_DEPS_MSG="${green}`echo "${DEPS_INSTALLED}"|grep -v "^\$"| tr '\n' ','| sed -e "s#,\\$##" -e 's#,#, #g' 2>/dev/null| fold -w 50 -s | sed '2,10 s/^/                /g' 2>/dev/null`${endcolour}"
-      MISSING_DEPS_MSG="${yellow}`echo "${DEPS_MISSING}"   |grep -v "^\$"| tr '\n' ','| sed -e "s#,\\$##" -e 's#,#, #g' 2>/dev/null| fold -w 50 -s | sed '2,10 s/^/                /g'`${endcolour}"
+      INSTALLED_DEPS_MSG="${green}$(echo "${DEPS_INSTALLED}" \
+        | grep -v "^\$" \
+        | tr '\n' ','   \
+        | sed           \
+          -e 's#,$##'   \
+          -e 's#,#, #g' \
+        | fold -w 50 -s \
+        | sed '2,20 s/^/                /g' 2>/dev/null)${endcolour}"
+
+      MISSING_DEPS_MSG="${yellow}$(echo "${DEPS_MISSING}" \
+        | grep -v "^\$" \
+        | tr '\n' ','   \
+        | sed           \
+          -e 's#,$##'   \
+          -e 's#,#, #g' \
+        | fold -w 50 -s \
+        | sed '2,20 s/^/                /g')${endcolour}"
 
       DEPS_ENTRY="Installed deps: ${INSTALLED_DEPS_MSG:-None}
 Missing deps:   ${MISSING_DEPS_MSG:-None}"
-
-    else
-
-      DEPS_ENTRY="Dependencies:   `list_deps "$PKGNAME" 2>/dev/null`"
 
     fi
 
     #250613 added desc
     MSG="
 Name:           ${PKGNAME}
-Description:    `echo ${pkg_desc:-No description} | fold -w 50 -s | sed '2,10 s/^/                /g'`
+Description:    $(echo ${pkg_desc:-No description} | fold -w 50 -s | sed '2,10 s/^/                /g')
 Size:           ${pkg_size:-Unknown}
 Status:         ${install_status:-Unknown}
 In Repo:        ${pkg_repo:-Not in any repos}
-Repo file:      `basename ${pkg_repo_file:-Not in any repositories} 2>/dev/null`
+Repo file:      $(basename ${pkg_repo_file:-Not in any repositories} 2>/dev/null)
 $DEPS_ENTRY"
 
   fi
 
-  # if not found in any repo, maybe a woof or alien (user-installed) package
+  # if not found in any repo, maybe a woof or alien (user-installed) package...
   if [ "$MSG" = "" ];then #if nothing found in any repo
 
-    PKGFILE="`list_downloaded_pkgs | grep -m1 "^$PKGNAME"`"
-
+    PKGFILE="$(get_pkg_filename "$PKGNAME")"
+    if [ -z "$PKGFILE" ] || [ ! -f "$PKGFILE" ];then
+      PKGFILE="$(list_downloaded_pkgs | grep -m1 "^$PKGNAME").$EX"
+    fi
+    
     # if the pkg is a downloaded file (in WORKDIR)
     if [ -f "$WORKDIR/$PKGFILE" ];then
-
       # get the file, and get its file size
       PKGFILE="$WORKDIR/${PKGFILE}"
-      [ "$pkg_size" = '' ] && pkg_size="`du -s -k "$PKGFILE" | cut -f1`K"
-      [ "$pkg_size" = '' ] && pkg_size="`grep -m1 "|${PKGNAME_ONLY}|" ${HOME}/.packages/*-installed-packages | cut -f6 -d'|' | head -1`"
-
+    
+      [ "$pkg_size" = '' ] && pkg_size="$(du -s -k "$PKGFILE" | cut -f1)K"
+      [ "$pkg_size" = '' ] && pkg_size="$(grep -m1 "|${PKGNAME_ONLY}|" ${HOME}/.packages/*-installed-packages | cut -f6 -d'|' | head -1)"
 
       # create msg for downloaded pkgs
       MSG="Name:           ${PKGNAME}
@@ -3121,18 +3074,26 @@ Status:         Downloaded
 Note:           Downloaded package, not in any repo.
 $DEPS_ENTRY"
 
-    # else, search for exact match, then pkg-*, then pkg_*, then pkg* in installed pkgs
-    elif [ "`grep -m1 "|${PKGNAME_ONLY}|" ${HOME}/.packages/user-installed-packages 2>/dev/null`"   \
-      -o "`grep -m1 "^${PKGNAME}|" ${HOME}/.packages/user-installed-packages 2>/dev/null`"   \
-      -o "`grep -m1 "^${PKGNAME}|" ${HOME}/.packages/*-installed-packages 2>/dev/null`"   \
-      -o "`grep -m1 "^${PKGNAME}-" ${HOME}/.packages/*-installed-packages 2>/dev/null`" \
-      -o "`grep -m1 "^${PKGNAME}_" ${HOME}/.packages/*-installed-packages 2>/dev/null`" \
-      -o "`grep -m1 "^${PKGNAME}" ${HOME}/.packages/*-installed-packages 2>/dev/null`" ];then
+    elif [ "$(is_usr_pkg "$PKGNAME")" = true ];then
 
       # get deps and size from its entry in user-installed-packages
-      DEPS_ENTRY="Dependencies:   `grep -m1 "^$PKGNAME" ${HOME}/.packages/user-installed-packages | cut -f9 -d'|' | sed -e 's/,+/,/g' -e 's/^+//g' -e 's/,$//g' 2>/dev/null`"
-      [ "$DEPS_ENTRY" = '' ] && DEPS_ENTRY="Dependencies:   `grep -m1 "^$PKGNAME" ${HOME}/.packages/*-installed-packages | cut -f9 -d'|' | sed -e 's/,+/,/' -e 's/^+//' -e 's/,$//' 2>/dev/null`"
-      pkg_size=`LANG=C grep -m1 "|$PKGNAME_ONLY|" $HOME/.packages/*-installed-packages | cut -f6 -d'|' | head -1`
+      DEPS_ENTRY="$(grep -m1 "^$PKGNAME|" ${HOME}/.packages/user-installed-packages \
+        | cut -f9 -d'|' \
+        | sed \
+          -e 's/,+/,/g' \
+          -e 's/^+//g' \
+          -e 's/,$//g' \
+        2>/dev/null)"
+
+      [ "$DEPS_ENTRY" = '' ] && DEPS_ENTRY="$(grep -m1 "^$PKGNAME" ${HOME}/.packages/*-installed-packages \
+        | cut -f9 -d'|' \
+        | sed \
+          -e 's/,+/,/' \
+          -e 's/^+//' \
+          -e 's/,$//' 2>/dev/null)"
+
+      pkg_size=$(LANG=C grep -m1 "|$PKGNAME_ONLY|" $HOME/.packages/*-installed-packages | cut -f6 -d'|' | head -1)
+
       # add K to end of pkg_size, if not there already
       [ "$pkg_size" != '' ] && pkg_size="${pkg_size}K" && pkg_size="${pkg_size//KK/K}"
 
@@ -3141,13 +3102,14 @@ $DEPS_ENTRY"
 Size:           ${pkg_size:-Unknown}
 Status:         ${install_status}
 Repo:           Alien package, not in any repo.
-$DEPS_ENTRY"
+Dependencies:   $DEPS_ENTRY"
 
     else # pkg wasn't found, it's unknown to Pkg
+
       MSG="$PKGNAME not found.
 
 Here are some packages in other repos:"
-      PLIST="`which_repo ${PKGNAME}`"
+      PLIST="$(which_repo ${PKGNAME})"
       [ "$PLIST" != "" ] && MSG="$MSG
 $PLIST"
       # create msg for alien pkgs
@@ -3156,7 +3118,7 @@ $PLIST"
 Name:           ${PKGNAME}
 Status:         ${install_status:-Unknown}
 Repo:           Alien package, not in $REPONAME repo.
-$DEPS_ENTRY"
+Dependencies:   $DEPS_ENTRY"
 
     fi
 
@@ -3179,19 +3141,21 @@ $DEPS_ENTRY"
 
 prepare_petbuild(){               # get 01mickos petbuild system from Git, if needed FUNCLIST
 
-  local gitcheck=`which git`
-
   # exit if no devx
-  [ "`which gcc`" = '' ] \
-    && echo "You need the devx SFS installed to compile packages." \
-    && rm /tmp/pkg/petbuild_prepared 2>/dev/null \
-    && exit 3
+  command gcc --version &>/dev/null || \
+    {
+      echo "You need the devx SFS installed to compile packages."
+      rm /tmp/pkg/petbuild_prepared 2>/dev/null
+      exit 3
+    }
 
   # exit if no git
-  [ "`$gitcheck`" = '' ] \
-    && echo "You need git installed to auto-install petbuild." \
-    && rm /tmp/pkg/petbuild_prepared 2>/dev/null \
-    && exit 3
+  command git --version &>/dev/null || \
+    {
+      echo "You need git installed to auto-install petbuild."
+      rm /tmp/pkg/petbuild_prepared 2>/dev/null
+      exit 3
+    }
 
   if [ ! -d /usr/share/petbuild ];then
     rm /tmp/pkg/petbuild_prepared 2>/dev/null && exit 1
@@ -3228,33 +3192,35 @@ prepare_petbuild(){               # get 01mickos petbuild system from Git, if ne
 
     # go into buildpet dir, check which Pup we have ($DISTRO_DB_SUBNAME)
     # and checkout the right branch for the running system
-    cd /usr/share/petbuild
+    cd /usr/share/petbuild || exit
 
-    # check the puppy running and checkout the relevant branch
-    if [ "`echo $DISTRO_DB_SUBNAME | grep slacko`" != '' ];then
-      if [ "`echo $DISTRO_DB_SUBNAME | grep '14.2'`" != '' ];then
-        git checkout slacko_142
-      else
-        git checkout slacko_141
-      fi
-    elif [ "`echo $DISTRO_DB_SUBNAME | grep tahrpup`" ];then
-      git checkout tahrpup
-    elif [ "`echo $DISTRO_DB_SUBNAME | grep stretch`" ];then
-      git checkout stretch || git checkout tahrpup
-    elif [ "`echo $DISTRO_DB_SUBNAME | grep xenialpup`" ];then
-      git checkout xenialpup || git checkout tahrpup
-    elif [ "$DISTRO_DB_SUBNAME" != '' ];then
-      git checkout tahrpup
-    else
-      echo "No pet builds available for your system ($DISTRO_DB_SUBNAME),"
-      echo "using buildpet instead.."
-      rm -rf /usr/share/petbuild 2>/dev/null
-    fi
+    git checkout generic
+
+#    # check the puppy running and checkout the relevant branch
+#    if [ "${DISTRO_DB_SUBNAME//slacko/}" != "${DISTRO_DB_SUBNAME" ];then
+#      if [ "${DISTRO_DB_SUBNAME//14.2}" != "$DISTRO_DB_SUBNAME" ];then
+#        git checkout slacko_142
+#      else
+#        git checkout slacko_141
+#      fi
+#    elif [ "`echo $DISTRO_DB_SUBNAME | grep tahrpup`" ];then
+#      git checkout tahrpup
+#    elif [ "`echo $DISTRO_DB_SUBNAME | grep stretch`" ];then
+#      git checkout stretch || git checkout tahrpup
+#    elif [ "`echo $DISTRO_DB_SUBNAME | grep xenialpup`" ];then
+#      git checkout xenialpup || git checkout tahrpup
+#    elif [ "$DISTRO_DB_SUBNAME" != '' ];then
+#      git checkout tahrpup
+#    else
+#      echo "No pet builds available for your system ($DISTRO_DB_SUBNAME),"
+#      echo "using buildpet instead.."
+#      rm -rf /usr/share/petbuild 2>/dev/null
+#    fi
 
     # buildpet setup finished, create flag
     echo 'true' > /tmp/pkg/petbuild_prepared
 
-    cd "$CURDIR"
+    cd "$CURDIR" || exit 
   fi
 }
 
@@ -3262,10 +3228,17 @@ prepare_petbuild(){               # get 01mickos petbuild system from Git, if ne
 pkg_build(){                      # build package ($1) from source (see BUILDTOOL in pkgrc) FUNCLIST
 
   # exit if devx not installed
-  [ "`which gcc`" = "" ]   && echo "You need the devx SFS installed to compile." && exit 1
+  command gcc --version &>/dev/null \
+    || { 
+      echo "You need the devx SFS installed to compile."
+      exit 1
+    }
 
   # get the settins from RC file
-  . ${PKGRC}
+  . "${PKGRC}"
+
+  # get pkg extension
+  EX=$(get_pkg_ext "${1:=$EX}")
 
   # we do a different build method for each supported build tool
   case $BUILDTOOL in
@@ -3273,39 +3246,40 @@ pkg_build(){                      # build package ($1) from source (see BUILDTOO
     petbuild) # by 01micko
 
       # use git to install the latest petbuild
-      prepare_petbuild
+      if [ ! -f  /tmp/pkg/petbuild_prepared ] && [ ! -d /usr/share/petbuild ];then
+        prepare_petbuild
+      fi
 
       # if petbuild not installed, quit
       [ ! -d /usr/share/petbuild ] && error "PetBuild not installed at /usr/share/petbuild." && exit 3
 
       # petbuild needs a package name, or exit
-      [ ! "$1" -o "$1" = "-" ] && print_usage pkg-build && exit 1 #220613 #250613
-
-      # get pkg extension
-      EX=`get_pkg_ext "$1"`
+      [ ! "$1" ] || [ "$1" = "-" ] && print_usage pkg-build && exit 1 #220613 #250613
 
       # get pkg name only, no extension or path
       PKGNAME="$(basename "$1" .$EX)"
 
       # get petbuild PKGNAME, then build using 01mickos petbuild
-      BUILDSCRIPT="`find /usr/share/petbuild -iname ${PKGNAME}"*.petbuild"| grep -m1 "$PKGNAME"`"
+      BUILDSCRIPT="$(find /usr/share/petbuild -iname "${PKGNAME}*.petbuild"| grep -m1 "$PKGNAME")"
 
       # if we got a build script
       if [ -f "$BUILDSCRIPT" ];then
-        cd `dirname "$BUILDSCRIPT"`
+        (
+        cd "$(dirname "$BUILDSCRIPT")" || exit
         # compile the pkg
-        bash *.petbuild
+        PKG_CONFIGURE="$PKG_CONFIGURE" PKG_CFLAGS="$PKG_CFLAGS" bash ./*.petbuild
         # after build, move any pets created to WORKDIR
         mv /usr/share/petbuild/0pets_out/*.pet "$WORKDIR" 2>/dev/null
         # back to prev dir (WORKDIR)
-        cd -
+        cd - || exit
+        )
       fi
 
       # if build script not found, exit
       [ ! -f "$BUILDSCRIPT" ] && echo "Build script for '$PKGNAME' not found in /usr/share/petbuild/" && exit 1
 
       # get the packages we just moved to WORKDIR
-      PKGFILES="`find "$WORKDIR" -iname "$PKGNAME*.pet"`"
+      PKGFILES="$(find "$WORKDIR" -iname "$PKGNAME*.pet")"
 
       # list any packages we just built
       [ "$PKGFILES" != '' ] && echo -e "${green}Success:${endcolour} Packages in $WORKDIR:" && echo "$PKGFILES"
@@ -3317,16 +3291,13 @@ pkg_build(){                      # build package ($1) from source (see BUILDTOO
       [ ! -d /usr/share/buildpet ] && error "buildpet not installed." && exit 1
 
       # buildpet expects a PKGNAME, or exit
-      [ ! "$1" -o "$1" = "-" ] && print_usage pkg-build && exit 1
-
-      # get pkg extension
-      EX=`get_pkg_ext "$1"`
+      [ ! "$1" ] || [ "$1" = "-" ] && print_usage pkg-build && exit 1
 
       # get pkg name (with version), no extension or path
       PKGNAME="$(basename "$1" .$EX)"
 
       # get the buildpet script of PKGNAME
-      BUILDSCRIPT="`find /usr/share/buildpet/ -name $PKGNAME"*"`"
+      BUILDSCRIPT="$(find /usr/share/buildpet/ -name "$PKGNAME*")"
 
       # if build script not found, exit
       [ ! -f "$BUILDSCRIPT" ] && echo "Build script for '$PKGNAME' not found in /usr/share/buildpet/" && exit 1
@@ -3345,20 +3316,17 @@ pkg_build(){                      # build package ($1) from source (see BUILDTOO
       ### (petbuild|buildpet) buildscipt on successful compile
 
       # exit if src2pkg not installed
-      [ "`which src2pkg`" = '' ] && error "src2pkg not installed." && error "Get it from http://distro.ibiblio.org/amigolinux/download/src2pkg/src2pkg-3.0-noarch-2.txz" && exit 3
+      [ "$(which src2pkg)" = '' ] && error "src2pkg not installed." && error "Get it from http://distro.ibiblio.org/amigolinux/download/src2pkg/src2pkg-3.0-noarch-2.txz" && exit 3
 
       # exit if $1 not given or valid
-      [ ! "$1" -o "$1" = "-" ]   && print_usage pkg-build && exit 1
+      [ ! "$1"  ] || [ "$1" = "-" ]   && print_usage pkg-build && exit 1
 
       # show src2pkg help if user supplied any of the help options
-      if [ "$1" = '-h'  -o "$1" = '-hh'  -o "$1" = '--help' -o "$1" = '--more-help' -o "$1" = '--list' ];then
+      if [ "$1" = '-h'  ] || [ "$1" = '-hh'  ] || [ "$1" = '--help' ] || [ "$1" = '--more-help' ] || [ "$1" = '--list' ];then
         src2pkg $1 | sed -e "s/  src2pkg /  $SELF -pb /g"
         echo -e "\n   See 'src2pkg' by amigo"
         exit 0
       fi
-
-      # get pkg extension.. not really needed here
-      EX=`get_pkg_ext "$1"`
 
       # use amigos src2pkg
       src2pkg $1
@@ -3371,15 +3339,15 @@ pkg_build(){                      # build package ($1) from source (see BUILDTOO
     sbopkg)   # slackware peeps
 
       # exit if not installed
-      [ "`which sbopkg`" = '' ] && error "Sbopkg not installed." && exit 3
+      [ "$(which sbopkg)" = '' ] && error "Sbopkg not installed." && exit 3
 
       # exit if no valid options
-      [ ! "$1" -o "$1" = "-" ]  && print_usage pkg-build && exit 1
+      [ ! "$1" ] || [ "$1" = "-" ]  && print_usage pkg-build && exit 1
 
       sbopkg -b "$1"
 
       # move any built pkgs to WORKDIR.. need a better way to do this
-      if [ "`find /tmp/* -iname $1*.t*`" != '' ];then
+      if [ "$(find /tmp/* -iname "$1*.t*")" != '' ];then
         mv /tmp/*.tgz "$WORKDIR" 2>/dev/null
         mv /tmp/*.txz "$WORKDIR" 2>/dev/null
         mv /tmp/*.tar.xz "$WORKDIR" 2>/dev/null
@@ -3414,7 +3382,7 @@ pkg_build(){                      # build package ($1) from source (see BUILDTOO
 pkg_repack(){                     # create package ($1) from its *.files list FUNCLIST
 
   # exit if no valid options
-  [ ! "$1" -o "$1" = "-" ] && print_usage pkg-repack && exit 1
+  [ ! "$1" ] || [ "$1" = "-" ] && print_usage pkg-repack && exit 1
 
   local list=''
   local pkg_ext=''
@@ -3424,22 +3392,24 @@ pkg_repack(){                     # create package ($1) from its *.files list FU
   local build_number=''
 
   # get pkg extension
-  pkg_ext=`get_pkg_ext "$1"`
+  pkg_ext=$(get_pkg_ext "$1")
 
   #get pkg name only, no extension or path
   PKGNAME="$(LANG=C basename "$1" .$pkg_ext)"
 
+  # don't rely on the given pkg name string, get the full name from repo if poss
+  PKGNAME=$(get_pkg_name "$PKGNAME")
+
+  # if the list is empty, pkg is not user installed or built in, cant show contents
+  [ "$(is_installed_pkg "$PKGNAME")" = false ] && echo "$PKGNAME needs to be installed." && exit 1
+
   # assume the file name from $1
   PKGFILE="${CURDIR}/${PKGNAME}.$pkg_ext"
 
-  # don't rely on the given pkg name string, get the full name from repo if poss
-  PKGNAME=`get_pkg_name "$PKGNAME"`
+  [ ! -f "${PKGFILE}" ] && PKGFILE="${CURDIR}/$(get_pkg_filename "$PKGNAME")"
 
   # get pkg name without version
-  PKGNAME_ONLY="`get_pkg_name_only "${PKGNAME}"`"
-
-  # if the list is empty, pkg is not user installed or built in, cant show contents
-  [ "`is_installed_pkg "$PKGNAME"`" = false ] && echo "$PKGNAME needs to be installed." && exit 1
+  PKGNAME_ONLY="$(get_pkg_name_only "${PKGNAME}")"
 
   # if the package to built already exists, ask user to delete it
   [ -f "${PKGFILE}" ] && echo "$PKGNAME.$pkg_ext already exists in $CURDIR" && rm -f "${PKGFILE}" 2>/dev/null
@@ -3448,12 +3418,12 @@ pkg_repack(){                     # create package ($1) from its *.files list FU
   [ -f "${PKGFILE}" ] && exit 0
 
   # get the build number, and increment by one
-  build_number="`grep -m1 "^$PKGNAME|$PKGNAME_ONLY|" ${HOME}/.packages/user-installed-packages ${HOME}/.packages/woof-installed-packages ${HOME}/.packages/devx-only-installed-packages ${HOME}/.packages/Packages-* | cut -f4 -d'|'`"
+  build_number="$(grep -m1 "^$PKGNAME|$PKGNAME_ONLY|" ${HOME}/.packages/user-installed-packages ${HOME}/.packages/woof-installed-packages ${HOME}/.packages/devx-only-installed-packages ${HOME}/.packages/Packages-* | cut -f4 -d'|')"
   build_number=${build_number:-0}
   build_number="-$(($build_number + 1))"
 
   # process the file list, copy each file to our pkg folder
-  pkg_contents "$PKGNAME_ONLY" | while read line
+  pkg_contents "$PKGNAME" | while read line
   do
     if [ -f "$line" ]; then
       linedir="$(dirname "${line}")"
@@ -3469,8 +3439,8 @@ pkg_repack(){                     # create package ($1) from its *.files list FU
 
   # pkg folder should be populated, now package it up and print final msg
   dir2pet "${CURDIR}/${PKGNAME}/" "$build_number"
-  rm -rf "${CURDIR}/${PKGNAME}/" 2>/dev/null
-  rm -rf "${CURDIR}/${PKGNAME}$build_number/" 2>/dev/null
+  rm -rf "${CURDIR:-?}/${PKGNAME}/" 2>/dev/null
+  rm -rf "${CURDIR:-?}/${PKGNAME}$build_number/" 2>/dev/null
   sync
 }
 
@@ -3487,8 +3457,8 @@ pkg_unpack(){                     # extract/unpack $1 to current dir FUNCLIST
 
   # get pkg details
   PKGFILE="$1"
-  PKGNAME=`get_pkg_name "$PKGFILE"`
-  PKGEXT=`get_pkg_ext "$PKGFILE"`
+  PKGNAME=$(get_pkg_name "$PKGFILE")
+  PKGEXT=$(get_pkg_ext "$PKGFILE")
 
   # exit if we dont have enough info
   [ "$PKGEXT" = '' ]  && error "Cant get package extension" && exit 1
@@ -3505,47 +3475,67 @@ pkg_unpack(){                     # extract/unpack $1 to current dir FUNCLIST
 
     deb)
       mkdir "$PKGNAME" 2>/dev/null
-      rm -rf "$PKGNAME"/* 2>/dev/null
+      rm -rf "${PKGNAME:-?}"/* 2>/dev/null
       dpkg-deb -x "$PKGFILE" "$PKGNAME"    # extracts main pkg contents
       result=$?
       dpkg-deb -e "$PKGFILE" "$PKGNAME"/DEBIAN # extracts deb control files
-      [ $result -eq 0 ] && echo -e "${green}Extracted${endcolour}: ${magenta}`basename $PKGFILE`${endcolour}" || error -e "${red}Error${endcolour}: Cannot extract $PKGFILE"
+      if [ $result -eq 0 ];then
+        echo -e "${green}Extracted${endcolour}: ${magenta}$(basename $PKGFILE)${endcolour}"
+      else
+        error -e "${red}Error${endcolour}: Cannot extract $PKGFILE"
+      fi
       return $result
       ;;
 
     rpm)
       mkdir "${PKGNAME}" 2>/dev/null
-      rm -rf "$PKGNAME"/* 2>/dev/null
+      rm -rf "${PKGNAME:-?}"/* 2>/dev/null
       # create dir called $PKGNAME, cd into it, extract the rpm in there
       cp "$PKGFILE" "$PKGNAME/"
-      cd "$PKGNAME" 1>/dev/null
+      cd "$PKGNAME" 1>/dev/null || exit 1
       # now extract the rpm contents into current dir
       rpm2cpio "$PKGFILE" | cpio -idmu &>/dev/null
       result=$?
       # clean up and leave
-      rm -f *.rpm 2>/dev/null
-      cd - 1>/dev/null
+      rm -f ./*.rpm 2>/dev/null
+      cd - 1>/dev/null || exit 1
       # final msg
-      [ $result -eq 0 ] && echo -e "${green}Success${endcolour}: File ${magenta}`basename $PKGFILE`${endcolour} extracted." || error "Cannot extract $PKGFILE"
+      if [ $result -eq 0 ];then
+        echo -e "${green}Success${endcolour}: File ${magenta}$(basename $PKGFILE)${endcolour} extracted."
+      else
+        error "Cannot extract $PKGFILE"
+      fi
       return $result
       ;;
 
     sfs)
 
       mkdir "/${PKGNAME}" 2>/dev/null
-      rm -rf "$PKGNAME"/* 2>/dev/null
-
+      rm -rf "${PKGNAME:-?}"/* 2>/dev/null
       # make mnt dir, mount sfs
       mkdir "/mnt/${PKGNAME}" 2>/dev/null
-      mount -t squashfs "$PKGFILE" /mnt/"$PKGNAME" -o loop 1>/dev/null || { error "Could not mount $PKGFILE"; exit 3; }
+      mount -t squashfs "$PKGFILE" /mnt/"$PKGNAME" -o loop 1>/dev/null || \
+      { 
+        error "Could not mount $PKGFILE"
+        exit 3
+      }
       # copy sfs contents into ./$PKGNAME
-      cp -a -Rf --remove-destination /mnt/"$PKGNAME" "$PKGNAME" || { error "Failed copying files from /mnt/$PKGNAME to ./$PKGNAME"; exit 4; }
+      cp -a -Rf --remove-destination /mnt/"$PKGNAME" "$PKGNAME" || \
+      { 
+        error "Failed copying files from /mnt/$PKGNAME to ./$PKGNAME"
+        exit 4 
+      }
       result=$?
       # clean up
       umount "/mnt/${PKGNAME}"
       rmdir "/mnt/${PKGNAME}"
       # final msg
-      [ $result -eq 0 ] && echo -e "${green}Success${endcolour}: File ${magenta}`basename $PKGFILE`${endcolour} extracted." || { error "Cannot extract $PKGFILE"; exit 7; }
+      if [ $result -eq 0 ];then
+        echo -e "${green}Success${endcolour}: File ${magenta}$(basename $PKGFILE)${endcolour} extracted." 
+      else 
+        error "Cannot extract $PKGFILE"
+        exit 7
+      fi
       return $result
       ;;
     pet)  file -b "$PKGFILE" | grep -i -q "^xz" && comp=xz || comp=gzip ;;
@@ -3563,7 +3553,15 @@ pkg_unpack(){                     # extract/unpack $1 to current dir FUNCLIST
   # if pkg is extractable with tar, then unpack
   case $PKGEXT in
   pet|tgz|gz|tbz|bz2|tlz|lzma|txz|xz)
-    ( umask 000 ; cat "$PKGFILE" | $comp -dc 2>/dev/null | tar -xf - 2> /dev/null && echo -e "${green}Success${endcolour}: File ${magenta}`basename $PKGFILE`${endcolour} extracted." || error "Cannot extract $PKGFILE" )
+    ( 
+      umask 000
+      # shellcheck disable=SC2002
+      cat "$PKGFILE"            \
+        | $comp -dc 2>/dev/null \
+        | tar -xf - 2>/dev/null \
+      && echo -e "${green}Success${endcolour}: File ${magenta}$(basename $PKGFILE)${endcolour} extracted." \
+      || error "Cannot extract $PKGFILE"
+    )
     ;;
   esac
 
@@ -3576,7 +3574,7 @@ pkg_unpack(){                     # extract/unpack $1 to current dir FUNCLIST
 pkg_combine(){                    # combine a pkg ($1) and deps into one single pkg FUNCLIST
 
   # exit if no valid options
-  [ ! "$1" -o "$1" = "-" ] && print_usage pkg-combine && exit 1
+  [ ! "$1" ] || [ "$1" = "-" ] && print_usage pkg-combine && exit 1
 
   . ${PKGRC}
 
@@ -3595,15 +3593,13 @@ pkg_combine(){                    # combine a pkg ($1) and deps into one single 
   local ask_opt=$ASK
   local force_opt=$FORCE
 
-  cd "$WORKDIR"
-
   # get pkg extension
-  EX=`get_pkg_ext "$1"`
+  EX=$(get_pkg_ext "$1")
 
   # get reliable package names
   PKGNAME="$(basename "$1" .$EX)"
-  PKGNAME=`get_pkg_name "$PKGNAME"`
-  PKGNAME_ONLY=`get_pkg_name_only "$PKGNAME"`
+  PKGNAME=$(get_pkg_name "$PKGNAME")
+  PKGNAME_ONLY=$(get_pkg_name_only "$PKGNAME")
 
   PKG_FILE="${WORKDIR}/${PKGNAME}.$EX" #the file to install
 
@@ -3615,10 +3611,15 @@ pkg_combine(){                    # combine a pkg ($1) and deps into one single 
   HIDE_USER_PKGS=false
 
   # get full pkg filename (inc name-ver.ext).. try repos first
-  PKG_FILENAME="`cut -f8 -d'|' ${HOME}/.packages/Packages-* | grep -m1 "^$PKGNAME"`"
+  PKG_FILENAME="$(get_pkg_filename "$PKGNAME")"
   # then WORKDIR if needed (dont include the combined pkgs)
-  [ "$PKG_FILENAME" = "" ] && PKG_FILENAME="`ls -1 "$WORKDIR" | grep -v "${SUFFIX}" | grep -v ".sfs\$" | grep -m1 "^$PKGNAME"`"
-
+  if [ "$PKG_FILENAME" = "" ];then
+    PKG_FILENAME="$(find "$WORKDIR" -type f -name "$PKGNAME*" \
+      | grep -v "${SUFFIX}"     \
+      | grep -v ".sfs\$"        \
+      | grep -m1 "^$PKGNAME")"
+    PKG_FILENAME="$(basename "$PKG_FILENAME")"
+  fi
   # just in case its empty, revert back to the earlier PKGNAME value
   [ "$PKG_FILENAME" = "" ] && PKG_FILENAME="$PKGNAME"
 
@@ -3629,27 +3630,31 @@ pkg_combine(){                    # combine a pkg ($1) and deps into one single 
 
   # check if the desired file has already been built
   [ "$COMBINE2SFS" = true ] && final_ext=sfs || final_ext=pet
-  [ -f "${WORKDIR}/${PKGNAME}-${SUFFIX}.$final_ext" ] && echo -e "File ${magenta}${WORKDIR}/${PKGNAME}-${SUFFIX}.${final_ext}${endcolour} already exists." && continue
+  if [ -f "${WORKDIR}/${PKGNAME}-${SUFFIX}.$final_ext" ];then
+    echo -e "File ${magenta}${WORKDIR}/${PKGNAME}-${SUFFIX}.${final_ext}${endcolour} already exists."
+    return
+  fi
 
   # get list of deps for PKGNAME, if no deps, exit
-  PKG_DEPLIST="`FORCE=$force_opt list_deps $PKGNAME_ONLY`"
+  PKG_DEPLIST="$(FORCE=$force_opt list_deps $PKGNAME_ONLY)"
   [ "$PKG_DEPLIST" = "" ] && echo "No need to combine, $PKGNAME has no dependencies." && exit 1
 
   # if exact match of pkgname is found in a repo list
-  if [ "`is_repo_pkg "$PKGNAME"`" = true ];then
+  if [ "$(is_repo_pkg "$PKGNAME")" = true ];then
 
     echo "Please wait.. Gathering dependency information."
 
     # get the deps of the pkg, but dont install
     FORCE=$force_opt find_deps "$PKGNAME"
-    ALL_DEPS="`cat $TMPDIR/deps_installed $TMPDIR/deps_missing 2>/dev/null | sort -u`"
+    ALL_DEPS="$(cat $TMPDIR/deps_installed $TMPDIR/deps_missing 2>/dev/null | sort -u)"
 
     # download the needed package
-    if [ ! -f "$PKG_FILE" -o "$FORCE" = true ];then
+    if [ ! -f "$PKG_FILE" ] || [ "$FORCE" = true ];then
       ASK=false pkg_download "$PKGNAME"
     fi
 
     # make work dirs
+    cd "$WORKDIR" || exit 1
     mkdir -p "$BUILD_DIR/"
     mkdir -p "$BUILD_DIR/${PKGNAME}-${SUFFIX}"
 
@@ -3663,34 +3668,34 @@ pkg_combine(){                    # combine a pkg ($1) and deps into one single 
 
 
     # make a cleaned list to go over (sanity check)
-    ALL_DEPS_LIST="`echo "$ALL_DEPS" | tr ',' '\n' | grep -v "^\$" | sort -u`"
+    ALL_DEPS_LIST="$(echo "$ALL_DEPS" | tr ',' '\n' | grep -v "^\$" | sort -u)"
 
     # go through each dep listed
     echo "$ALL_DEPS_LIST" | while read LINE
     do
 
-      [ "$LINE" = "" -o "$LINE" = "-" -o "$LINE" = " " -o "$LINE" = "," -o "$LINE" = ", " ] && continue
+      [ "$LINE" = "" ] || [ "$LINE" = "-" ] || [ "$LINE" = " " ] || [ "$LINE" = "," ] || [ "$LINE" = ", " ] && continue
 
       # only include builtins if HIDE_BUILTINS=true
-      [ "`is_builtin_pkg "$LINE"`" = true -a "$HIDE_BUILTINS" = true ] && continue
+      [ "$(is_builtin_pkg "$LINE")" = true ] && [ "$HIDE_BUILTINS" = true ] && continue
 
       # only include devx pkgs if user gave the -f option
-      [ "`is_devx_pkg "$LINE"`" = true -a "$force_opt" = false ] && continue
+      [ "$(is_devx_pkg "$LINE")" = true ] && [ "$force_opt" = false ] && continue
 
       # download the matching package(s)
-      [ "`list_downloaded_pkgs "$LINE"`" = "" ] && ASK=false pkg_download "$LINE"
+      [ "$(list_downloaded_pkgs "$LINE")" = "" ] && ASK=false pkg_download "$LINE"
 
       # get the downloaded file
-      PKGDEP="`find "$WORKDIR" -maxdepth 1 -type f -name "${LINE}*" | grep -v ".sfs\$" | grep -v "${SUFFIX}" | head -1`"
+      PKGDEP="$(find "$WORKDIR" -maxdepth 1 -type f -name "${LINE}*" | grep -v ".sfs\$" | grep -v "${SUFFIX}" | head -1)"
 
       # re-try download in other repos if needed
       if [ ! -f "$PKGDEP" ];then
-        PKGREPO=''; PKGREPO="`LANG=C which_repo $LINE | cut -f2 -d' ' | head -1`"
+        PKGREPO=''; PKGREPO="$(LANG=C which_repo $LINE | cut -f2 -d' ' | head -1)"
         [ "$PKGREPO" != "" ] && ASK=false pkg_download "$LINE"
       fi
 
       #if downloaded
-      if [ -f "$PKGDEP" -o "$FORCE" = true ];then
+      if [ -f "$PKGDEP" ] || [ "$FORCE" = true ];then
 
         # copy dep to the tmp dir, with the main pkg
         if [ ! -f "$BUILD_DIR/$PKGDEP" ];then
@@ -3706,12 +3711,12 @@ pkg_combine(){                    # combine a pkg ($1) and deps into one single 
     done
 
     # we should now be ready to make our combined pkg
-    cd "$BUILD_DIR"
+    cd "$BUILD_DIR" || exit 1
 
     PARENTPKG=${PKGNAME}
 
     # for all pkgs in the tmp dir (nto including any 'combined' pkgs)
-    TMP_PKGS="`find "$BUILD_DIR/" -maxdepth 1 -type f -name "*" | grep -v $SUFFIX | grep -v ^$ | grep -v ' ' | sort -u`"
+    TMP_PKGS="$(find "$BUILD_DIR/" -maxdepth 1 -type f -name "*" | grep -v $SUFFIX | grep -v ^$ | grep -v ' ' | sort -u)"
 
     local count=1
 
@@ -3719,21 +3724,21 @@ pkg_combine(){                    # combine a pkg ($1) and deps into one single 
     do
 
       # skip if not a valid pkg file
-      [ ! "$i" -o "$i" = ' ' -o "$i" = '' -o ! -f "$i" ] && continue
+      [ -z "$i" ] || [ "$i" = ' ' ] || [ ! -f "$i" ] && continue
 
       # dont include the combined pkgs
-      [ "`echo "$i" | grep -m1 "${SUFFIX}"`" != "" ] && continue
+      [ "$(echo "$i" | grep -m1 "${SUFFIX}")" != "" ] && continue
 
       # get the extensions of each file .. they might be from different repos, so cant use $EX
-      base="`basename "$i" 2>/dev/null`"
-      FILE_EXT=`get_pkg_ext "$base"`
+      base="$(basename "$i" 2>/dev/null)"
+      FILE_EXT=$(get_pkg_ext "$base")
 
-      [ ! "$base" -o "$base" = ' ' -o "$base" = '' ] && continue
+      [ ! "$base" ] || [ "$base" = ' ' ] || [ "$base" = '' ] && continue
 
       # get name without version for this pkg ($i)
-      name_only=`get_pkg_name_only "$i"`
+      name_only=$(get_pkg_name_only "$i")
 
-      [ ! "$name_only" -o "$name_only" = ' ' -o "$name_only" = '' ] && continue
+      [ ! "$name_only" ] || [ "$name_only" = ' ' ] || [ "$name_only" = '' ] && continue
 
       CONFIRM=y
       if [ "$ask_opt" = true ];then
@@ -3746,7 +3751,7 @@ pkg_combine(){                    # combine a pkg ($1) and deps into one single 
 
       # skip pkg if user wants to skip it
       if [ "$CONFIRM" != 'y' ];then
-        rm "$i"
+        rm "${i:-?}" &>/dev/null
         continue
       fi
 
@@ -3769,7 +3774,8 @@ pkg_combine(){                    # combine a pkg ($1) and deps into one single 
         fi
 
         # now remove the pet and extract folder
-        rm "${i}"
+        rm "${i:-?}"
+        # shellcheck disable=SC2115
         rm -rf "${i/.pet/}/"
         sync
         ;;
@@ -3818,7 +3824,8 @@ pkg_combine(){                    # combine a pkg ($1) and deps into one single 
         fi
 
         # now remove the deb and extracted folder
-        rm "$i"
+        rm "${i:-?}"
+        # shellcheck disable=SC2115
         rm -rf "$pkg_dir"
         sync
         ;;
@@ -3835,7 +3842,8 @@ pkg_combine(){                    # combine a pkg ($1) and deps into one single 
         fi
 
         # remove the package and folder we just extracted
-        rm "$i"
+        rm "${i:-?}"
+        # shellcheck disable=SC2115
         rm -rf "${i/.*/}/"
         sync
         ;;
@@ -3851,7 +3859,8 @@ pkg_combine(){                    # combine a pkg ($1) and deps into one single 
         fi
 
         # remove the package and folder we just extracted
-        rm "$i"
+        rm "${i:-?}"
+        # shellcheck disable=SC2115
         rm -rf "${i/.rpm/}/"
         ;;
 
@@ -3870,16 +3879,15 @@ pkg_combine(){                    # combine a pkg ($1) and deps into one single 
     # concat the post install scripts (for puppy, slackware, arch, debian/ubuntu, etc) into 'pinstall.sh'
     for i in ${PARENTPKG}-${SUFFIX}/pinstall_* ${PARENTPKG}-${SUFFIX}/install/doinst_* ${PARENTPKG}-${SUFFIX}/DEBIAN/postinst_*
     do
-      [ -z ${PARENTPKG}-${SUFFIX}/${i} ] && continue
-      cd ${PARENTPKG}-${SUFFIX}/ 2>/dev/null
+      [ ! -f ${PARENTPKG}-${SUFFIX}/${i} ] && continue
 
-      files=`find . -type f -iname "$(basename $i)"`
+      cd ${PARENTPKG}-${SUFFIX}/ 2>/dev/null || exit 1
 
-      for file in $files
+      for file in find . -type f -iname "$(basename "$i")"
       do
         if [ -f "$file" ];then
           echo "Appending ${file} to $pinstall_file"
-          cat ${file} | grep -vE '^#!|^exit|exit 0|exit 1' >> "$pinstall_file"
+          grep -vE '^#!|^exit|exit 0|exit 1' ${file} >> "$pinstall_file"
           echo '' >> "$pinstall_file"
         fi
       done
@@ -3903,16 +3911,16 @@ pkg_combine(){                    # combine a pkg ($1) and deps into one single 
     do
       if [ -d $BUILD_DIR/${PARENTPKG}-${SUFFIX}/usr/lib/${libdir}/ ];then
         mv -n -u $BUILD_DIR/${PARENTPKG}-${SUFFIX}/usr/lib/${libdir}/* $BUILD_DIR/${PARENTPKG}-${SUFFIX}/usr/lib/
-        cd $BUILD_DIR/${PARENTPKG}-${SUFFIX}/usr/lib
-        rmdir ${libdir}/
-        ln -s ${libdir}/ .
-        cd -
+        (
+          cd $BUILD_DIR/${PARENTPKG}-${SUFFIX}/usr/lib || exit 1
+          rmdir ${libdir:-?}/ && ln -s ${libdir}/ .
+        )
       fi
     done
 
 
     # now we are ready to build our combined pkg
-    [ "`pwd`" != "$BUILD_DIR" ] && cd "$BUILD_DIR/"
+    [ "$PWD" != "$BUILD_DIR" ] && { cd "$BUILD_DIR/" || exit 1; }
 
 
     # if not building SFS, build a .pet
@@ -3935,8 +3943,8 @@ pkg_combine(){                    # combine a pkg ($1) and deps into one single 
       esac
 
       TARBALL="${PKGNAME}-${SUFFIX}.tar.$TAREXT"
-      FULLSIZE="`stat --format=%s ${TARBALL}`"
-      MD5SUM="`md5sum $TARBALL | cut -f 1 -d ' '`"
+      FULLSIZE="$(stat --format=%s ${TARBALL})"
+      MD5SUM="$(md5sum $TARBALL | cut -f 1 -d ' ')"
       echo -n "$MD5SUM" >> $TARBALL
       sync
 
@@ -3945,13 +3953,13 @@ pkg_combine(){                    # combine a pkg ($1) and deps into one single 
 
       if [ $? -eq 1 ];then
         echo "Cannot create PET file ${PKGNAME}-${SUFFIX} from dir."
-        error "Please check `pwd`"
+        error "Please check $PWD"
       fi
 
       # move our new PET to $WORKDIR
       mv ${PKGNAME}-${SUFFIX}.pet $WORKDIR/${PKGNAME}-${SUFFIX}.pet
       # get the size
-      s=`LANG=C du -m "$WORKDIR/${PKGNAME}-${SUFFIX}.pet" | sed "s/\s.*//"`
+      s=$(LANG=C du -m "$WORKDIR/${PKGNAME}-${SUFFIX}.pet" | sed "s/\s.*//")
 
     else #240613  build a .sfs
       echo "Building SFS package.. Please wait.."
@@ -3959,16 +3967,16 @@ pkg_combine(){                    # combine a pkg ($1) and deps into one single 
       dir2sfs "${PKGNAME}-${SUFFIX}" 1>/dev/null
 
       # get the full file name, it may (or not) have been appended with '-DISTRO_VERSION'
-      SFS_FILE=`find . -maxdepth 1 -type f -name "*${PKGNAME}-${SUFFIX}*.sfs" | head -1`
+      SFS_FILE=$(find . -maxdepth 1 -type f -name "*${PKGNAME}-${SUFFIX}*.sfs" | head -1)
 
-      s=`LANG=C du -m "${SFS_FILE}" | sed "s/\s.*//"`
-      MD5SUM=`md5sum "$SFS_FILE" | cut -f1 -d ' '`
+      s=$(LANG=C du -m "${SFS_FILE}" | sed "s/\s.*//")
+      MD5SUM=$(md5sum "$SFS_FILE" | cut -f1 -d ' ')
       mv "$SFS_FILE" "$WORKDIR/"
     fi
 
     # done, go back to work dir from WORKDIR/build_pkg
-    cd "$WORKDIR"
-    rm -R  "$BUILD_DIR/" 2>/dev/null
+    cd "$WORKDIR" || exit 1
+    rm -R  "${BUILD_DIR:-?}/" 2>/dev/null
 
     # create install command
     if [ "$COMBINE2SFS" = false ];then
@@ -3989,7 +3997,7 @@ pkg_combine(){                    # combine a pkg ($1) and deps into one single 
     exit 1
   fi
 
-  cd "$PREVDIR"
+  cd "$PREVDIR" || exit 1
 }
 
 
@@ -3999,7 +4007,7 @@ merge_pkg(){                      # merge the given comma-separated packages FUN
   [ ! "$1" ] && print_usage merge && exit 1
   [ "$(echo "$1" |grep ',')" = "" ] && print_usage merge && exit 1
 
-  cd "$WORKDIR" 1>/dev/null
+  cd "$WORKDIR" 1>/dev/null || exit 1
 
   local PKG_LIST="$(echo "${1}" | tr ',' '\n' | sort -u)"
   local SUFFIX=''
@@ -4011,7 +4019,7 @@ merge_pkg(){                      # merge the given comma-separated packages FUN
     # add deps of pkgs to list of pkgs to merge
     for package in $PKG_LIST
     do
-      PKG_LIST="$PKG_LIST $(list_deps $package)"
+      PKG_LIST="$PKG_LIST $(list_deps "$package")"
     done
     PKG_LIST="$(echo "$PKG_LIST" | tr ' ' '\n' | sort -u)"
 
@@ -4028,7 +4036,7 @@ merge_pkg(){                      # merge the given comma-separated packages FUN
   echo
 
   # get a new package name for the new, merged package
-  local PKGNAME="`get_pkg_name "$(basename "${1//,*/}")" 2>/dev/null`"
+  local PKGNAME="$(get_pkg_name "$(basename "${1//,*/}")" 2>/dev/null)"
   bash -c 'read -e -r -p "Enter a package name and hit ENTER: " -i "${PKGNAME}-MERGED${SUFFIX}" NEWPKGNAME; echo $NEWPKGNAME > /tmp/pkg/NEWPKGNAME'
   echo
   NEWPKGNAME="$(cat /tmp/pkg/NEWPKGNAME)"
@@ -4038,20 +4046,20 @@ merge_pkg(){                      # merge the given comma-separated packages FUN
     return 1
   fi
 
-  rm -rf "${NEWPKGNAME}/" &>/dev/null
+  rm -rf "${NEWPKGNAME:-?}/" &>/dev/null
   mkdir "${NEWPKGNAME}"
 
   # remove any old folders
-  rm -rf ${WORKDIR}${NEWPKGNAME}/ &>/dev/null
+  rm -rf ${WORKDIR:-?}${NEWPKGNAME}/ &>/dev/null
 
   # for each package to merge
   for package in $PKG_LIST
   do
 
     # get the package details
-    local PKGNAME="`get_pkg_name "$(basename "$package")" 2>/dev/null`"
-    local PKGNAME_ONLY="`get_pkg_name_only "$PKGNAME" 2>/dev/null`"
-    local PKGEXT="`get_pkg_ext "$PKGNAME"`"
+    local PKGNAME="$(get_pkg_name "$(basename "$package")" 2>/dev/null)"
+    local PKGNAME_ONLY="$(get_pkg_name_only "$PKGNAME" 2>/dev/null)"
+    local PKGEXT="$(get_pkg_ext "$PKGNAME")"
     local PKGFILE=''
 
     [ "$PKGNAME" = ""  ] && continue
@@ -4059,17 +4067,18 @@ merge_pkg(){                      # merge the given comma-separated packages FUN
     [ "$PKGNAME" = "-" ] && continue
 
     # download it
-    pkg_download "$PKGNAME"
-
-    retval=$?
-
-    if [ $retval -eq 1 ];then
+    pkg_download "$PKGNAME" || \
+    {
       echo -e "${yellow}Warning${endcolour}: package '$PKGNAME' not downloaded."
       continue
-    fi
+    }
 
     # get the downloaded file
-    PKGFILE="$(find $WORKDIR -maxdepth 1 -type f -name "${PKGNAME}*${PKGEXT}")"
+    [ ! -f "$PKGFILE" ] && \
+      PKGFILE="$(find $WORKDIR -maxdepth 1 -type f -name "$(get_pkg_filename "$PKGNAME")")"
+
+    [ ! -f "$PKGFILE" ] && \
+      PKGFILE="$(find $WORKDIR -maxdepth 1 -type f -name "${PKGNAME}*${PKGEXT}")"
 
     [ ! -f "$PKGFILE" ] && \
       PKGFILE="$(find $WORKDIR -maxdepth 1 -type f -name "${PKGNAME_ONLY}_*${PKGEXT}")"
@@ -4084,7 +4093,7 @@ merge_pkg(){                      # merge the given comma-separated packages FUN
 
     # unpack the downloaded file
     pkg_unpack "$PKGFILE"
-    rm "${PKGFILE}"
+    rm "${PKGFILE:-?}"
 
     # move the unpacked files into our new package dir
     PKGDIR="$(find $WORKDIR -maxdepth 1 -type d -name "${PKGNAME}*" | grep -v ${NEWPKGNAME})"
@@ -4095,7 +4104,7 @@ merge_pkg(){                      # merge the given comma-separated packages FUN
     fi
 
     cp -R "$PKGDIR"/* "$NEWPKGNAME"
-    rm -rf "${PKGDIR}/"
+    rm -rf "${PKGDIR:-?}/"
   done
 
   if [ ! -d "${WORKDIR}/$NEWPKGNAME" ];then
@@ -4112,8 +4121,8 @@ merge_pkg(){                      # merge the given comma-separated packages FUN
   # create the merged PET package
   dir2pet "${NEWPKGNAME}/" || error "Could not create $NEWPKGNAME} PET file"
 
-  rm -rf "./${NEWPKGNAME}/" &>/dev/null
-  rm -rf "${WORKDIR}/${NEWPKGNAME}/" &>/dev/null
+  rm -rf "./${NEWPKGNAME:-?}/" &>/dev/null
+  rm -rf "${WORKDIR:-?}/${NEWPKGNAME:-?}/" &>/dev/null
 
   # get the filename of the new PET package
   NEWPKGFILENAME="$(find . -maxdepth 1 -type f -name "${NEWPKGNAME}*.pet")"
@@ -4132,19 +4141,19 @@ merge_pkg(){                      # merge the given comma-separated packages FUN
 split_pkg(){                      # split package ($1) into dev, doc, nls packages FUNCLIST
 
   # make sure the package exists
-  [ ! "$1" -o ! -f "$1" ] && print_usage split && exit 1
+  [ ! "$1" ] || [ ! -f "$1" ] && print_usage split && exit 1
 
-  local PKGNAME="`get_pkg_name "$(basename "$1")" 2>/dev/null`"
-  local PKGNAME_ONLY="`get_pkg_name_only "$PKGNAME" 2>/dev/null`"
+  local PKGNAME="$(get_pkg_name "$(basename "$1")" 2>/dev/null)"
+  local PKGNAME_ONLY="$(get_pkg_name_only "$PKGNAME" 2>/dev/null)"
   local PKGEXT="pet"
 
   # get package extension
-  PKGEXT="`get_pkg_ext "$1"`"
+  PKGEXT="$(get_pkg_ext "$1")"
 
   pkg_unpack "$1" &>/dev/null
 
   # get the package directory we just extracted
-  local PKG_PATH="$(find $(dirname "$PKGNAME") -maxdepth 1 -type d -iname "$PKGNAME" | head -1)"
+  local PKG_PATH="$(find "$(dirname "$PKGNAME")" -maxdepth 1 -type d -iname "$PKGNAME" | head -1)"
 
   # get the full path to the package dir (dir with contents of pkg to be split)
   PKG_PATH="$(realpath "$PKG_PATH")"
@@ -4199,7 +4208,10 @@ split_pkg(){                      # split package ($1) into dev, doc, nls packag
 
   cd "$PKG_PATH" &>/dev/null || { echo "Not found: $PKG_PATH"; return 1; }
 
-  for i in $(find -mindepth 1)
+  local files_in_current_dir
+  files_in_current_dir="$(find -mindepth 1)"
+  
+  for i in $files_in_current_dir
   do
   	# if the file no longer exists, skip this iteration
   	[ ! -e "$i" ] && continue
@@ -4268,6 +4280,7 @@ split_pkg(){                      # split package ($1) into dev, doc, nls packag
   [ -z "$is_empty" ] && rm -rf "$PKG_PATH"
 
   # go back to where we started (where the main package lives)
+  # shellcheck disable=SC2164
   [ -d "$CURDIR" ] && cd "$CURDIR" &>/dev/null
 
   # build each package from the package dir
@@ -4305,19 +4318,17 @@ split_pkg(){                      # split package ($1) into dev, doc, nls packag
 pkg_download(){                   # download a pkg ($1) to WORKDIR FUNCLIST
 
   # exit if no valid options
-  [ ! "$1" -o "$1" = "-" ] && print_usage download && exit 1
+  [ ! "$1" ] || [ "$1" = "-" ] && print_usage download && exit 1
 
-  . ${PKGRC}
+  . "${PKGRC}"
 
   local pkg_ext=''        # extension of pkg, empty if not a supported pkg ext
   local PKGNAME=''        # the pkgname with version
-  local ORIG_PKGNAME=''   # keeps the original pkg name ($1)
   local PKG_FILENAME=''   # package file name (field 8 of repo, with extension)
   local PKGFILE=''        # full path to package file
   local NET=''            # 1 or 0 if net connection available
   local curr_repo=''      # name of current repo in the loop
   local curr_repo_ext=''  # pkg ext for the current repo in the loop
-  local prev_repo_url=''  # holder for the prev checked url we know is working
   local curr_repo_url=''  # mirror that is used to download the pkg
   local curr_repo_url1='' # mirror1 for the current repo in the loop
   local curr_repo_url2='' # mirror2 for the current repo in the loop
@@ -4326,23 +4337,24 @@ pkg_download(){                   # download a pkg ($1) to WORKDIR FUNCLIST
   local pkg_in_repo=''    # true if pkg found in ANY repo, else false
 
   # get pkg extension
-  pkg_ext=`get_pkg_ext "$1"`
+  pkg_ext=$(get_pkg_ext "$1")
 
   # get pkg name with version (if given!), no extension or path
   PKGNAME="$(basename "$1" .$pkg_ext)"
-
   # get full package name from given pkg name string .. vlc -> vlc-1.2.3-blah
-  PKGNAME=`get_pkg_name "$PKGNAME"`
+  PKGNAME=$(get_pkg_name "$PKGNAME")
 
   # the file to save to.. not reliable till we checked the repos
   PKGFILE="${WORKDIR}/${PKGNAME}.$pkg_ext"
-  PKG_FNAME_GUESS="$PKGFILE"
+  [ ! -f "$PKGFILE" ] && PKGFILE="${WORKDIR}/$(get_pkg_filename "$PKGNAME")"
+  #PKG_FNAME_GUESS="$PKGFILE"
+  
   # set download options
   [ "$FORCE" = true  ] && CONTINUE='' || CONTINUE='-c'
   [ "$ASK"  != true  ] && QTAG=''
 
   #if pkg not yet downloaded, or we are downloading all, or we are forcing downloads
-  if [ ! -f "$PKGFILE" -o "$NO_INSTALL" = true -o "$FORCE" = true ];then
+  if [ ! -f "$PKGFILE" ] || [ "$NO_INSTALL" = true ] || [ "$FORCE" = true ];then
 
     # mark this pkg as not yet downloaded
     DONE=false
@@ -4358,44 +4370,42 @@ pkg_download(){                   # download a pkg ($1) to WORKDIR FUNCLIST
       sources_file="${HOME}/.pkg/sources"
 
       # check if $repo_file contains the given pkg
-      pkg_in_this_repo="`LANG=C cut -f1,2,7,8 -d'|' ${HOME}/.packages/$repo_file 2>/dev/null | sed -e "s/^/|/" -e "s/$/|/" | grep -m1 "|${PKGNAME}|"`"
-      [ "$pkg_in_this_repo" = '' ] && pkg_in_this_repo="`LANG=C cut -f1,2,7,8 -d'|' ${HOME}/.packages/$repo_file 2>/dev/null | sed -e "s/^/|/" -e "s/$/|/" | grep -m1 "|${PKGNAME}"`"
+      pkg_in_this_repo="$(LANG=C cut -f1,2,7,8 -d'|' ${HOME}/.packages/$repo_file 2>/dev/null \
+        | grep -m1 "^${PKGNAME}|")"
+
+      [ "$pkg_in_this_repo" = '' ] && pkg_in_this_repo="$(LANG=C cut -f1,2,7,8 -d'|' ${HOME}/.packages/$repo_file 2>/dev/null \
+        | grep -m1 "|${PKGNAME_ONLY}|")"
+
+      [ "$pkg_in_this_repo" = '' ] && pkg_in_this_repo="$(LANG=C cut -f1,2,7,8 -d'|' ${HOME}/.packages/$repo_file 2>/dev/null \
+        | grep -m1 "|${PKGFILENAME}\$")"
 
       # if package file found in current repo file
       if [ "$pkg_in_this_repo" != "" ];then #if true, its an exact match
 
         # get name of current repo in loop
         prev_repo="$curr_repo"
-        curr_repo="`LANG=C grep $repo_file $sources_file 2>/dev/null | cut -f1 -d'|'`"
+        curr_repo="$(LANG=C grep -m1 $repo_file $sources_file 2>/dev/null | cut -f1 -d'|')"
 
         # get ext of cur repo, it might be different
-        curr_repo_ext="`LANG=C grep $repo_file $sources_file 2>/dev/null| cut -f2 -d'|'`"
-
-        # keep a copy of the PKGNAME we got from `get_pkg_name $1`
-        ORIG_PKGNAME=$PKGNAME
-
-        # get proper PKGNAME (inc name-ver) from the repo
-        PKGNAME="`echo "$pkg_in_this_repo" | cut -f3 -d'|'`"
-        # just in case it didn't work, revert back to the old PKGNAME value
-        [ "$PKGNAME" = "" ] && PKGNAME="$ORIG_PKGNAME"
+        curr_repo_ext="$(LANG=C grep -m1 $repo_file $sources_file 2>/dev/null| cut -f2 -d'|')"
 
         # get full pkg FILENAME (inc name-ver.ext) from the repo
-        PKG_FILENAME="`echo "$pkg_in_this_repo" | cut -f5 -d'|'`"
+        PKG_FILENAME="$(basename "$PKGFILE")"
 
-        # just in case its empty, revert back to the earlier PKGNAME value
-        [ "$PKG_FILENAME" = "" ] && PKG_FILENAME="$PKGNAME"
+        # just in case its empty, revert back to the earlier value
+        [ "$PKG_FILENAME" = "" ] && PKG_FILENAME="$PKGNAME.$pkg_ext"
 
         # update the filename to check/download
         PKGFILE="${WORKDIR}/${PKG_FILENAME}"
 
         # skip if downloaded already, print msg
-        [ -f "$PKGFILE" -a "$FORCE" = false ] && DONE=true && echo -e "Already downloaded ${magenta}${PKG_FILENAME}${endcolour}" && continue
+        [ -f "$PKGFILE" ] && [ "$FORCE" = false ] && DONE=true && echo -e "Already downloaded ${magenta}${PKG_FILENAME}${endcolour}" && continue
 
         # update the package name, based on PKG_FILENAME
         PKGNAME="$(basename "$PKG_FILENAME" .$curr_repo_ext)"
 
         # update generic name
-        PKGNAME_ONLY="`get_pkg_name_only "$PKGNAME"`"
+        PKGNAME_ONLY="$(get_pkg_name_only "$PKGNAME")"
 
         if [ "${PKG_FILENAME}" = '' ];then
           error "Cant find pkg file name, needed to download"
@@ -4403,7 +4413,7 @@ pkg_download(){                   # download a pkg ($1) to WORKDIR FUNCLIST
         fi
 
         # skip pings and download if already downloaded.. unless forcing download
-        if [ ! -f "$PKGFILE" -o "$FORCE" = true ];then
+        if [ ! -f "$PKGFILE" ] || [ "$FORCE" = true ];then
 
           # ask user to download
           echo -en "Download ${magenta}${PKGNAME_ONLY}${endcolour} from ${lightblue}${curr_repo}${endcolour} repo$QTAG:  "
@@ -4419,34 +4429,29 @@ pkg_download(){                   # download a pkg ($1) to WORKDIR FUNCLIST
             echo # start a new line
 
             # get the subdir (from repo line) that the package lives in
-            sub_dir="`echo "$pkg_in_this_repo" | cut -f4 -d'|' | sed 's/^\.//'`"
+            sub_dir="$(echo "$pkg_in_this_repo" | cut -f3 -d'|' | sed 's/^\.//')"
 
             if [ "$sub_dir" = "." ];then
               sub_dir=''
             fi
 
-            # pre-woof get subdir
-            if [ "$sub_dir" != "" ] && [ -f "$HOME/.packages/${repo_file}_subdirs" ];then
-              sub_dir="`grep -m1 "^$PKGNAME|" "$HOME/.packages/${repo_file}_subdirs"  2>/dev/null | cut -f7 -d'|'`"
-            fi
-
             # get repo mirrors (only url1 is required .. we also add a final /)
-            curr_repo_url1="`LANG=C grep $repo_file $sources_file 2>/dev/null| cut -f4 -d'|'`/"
-            curr_repo_url2="`LANG=C grep $repo_file $sources_file 2>/dev/null| cut -f5 -d'|'`/"
-            curr_repo_url3="`LANG=C grep $repo_file $sources_file 2>/dev/null| cut -f6 -d'|'`/"
-            curr_repo_url4="`LANG=C grep $repo_file $sources_file 2>/dev/null| cut -f7 -d'|'`/"
+            curr_repo_url1="$(LANG=C grep -m1 $repo_file $sources_file 2>/dev/null| cut -f4 -d'|')/"
+            curr_repo_url2="$(LANG=C grep -m1 $repo_file $sources_file 2>/dev/null| cut -f5 -d'|')/"
+            curr_repo_url3="$(LANG=C grep -m1 $repo_file $sources_file 2>/dev/null| cut -f6 -d'|')/"
+            curr_repo_url4="$(LANG=C grep -m1 $repo_file $sources_file 2>/dev/null| cut -f7 -d'|')/"
 
             # make a space separated list of all our repo URLs
             curr_repo_url_list="$curr_repo_url1 $curr_repo_url2 $curr_repo_url3 $curr_repo_url4"
 
             # clean up the list, remove any double slashes at the end of each URL
-            curr_repo_url_list="`echo "$curr_repo_url_list" | sed -e "s|// |/ |g" -e "s|//\$|/\$|g"`"
+            curr_repo_url_list="$(echo "$curr_repo_url_list" | sed -e "s|// |/ |g" -e "s|//\$|/\$|g")"
 
             # update the ext to that of current repo
             pkg_ext="$curr_repo_ext"
 
             # get the best repo mirror
-            #if [ "$prev_repo" != "$current_repo"  -a -f $TMPDIR/curr_repo_url ] || [ ! -f $TMPDIR/curr_repo_url ];then
+            #if [ "$prev_repo" != "$current_repo"  ] && [ -f $TMPDIR/curr_repo_url ] || [ ! -f $TMPDIR/curr_repo_url ];then
               #echo "Checking '$curr_repo' repo mirrors..."
               for URL in $curr_repo_url_list
               do
@@ -4454,12 +4459,12 @@ pkg_download(){                   # download a pkg ($1) to WORKDIR FUNCLIST
                 [ "$URL" = '/' ] && continue
                 [ "$URL" = '' ] && continue
                 # add some system values into the repo URL (arch, distro version, etc.. from DISTRO_SPECS)
-                URL="`echo "$URL"| sed -e 's@${DBIN_ARCH}@'$DBIN_ARCH'@g'`"
-                URL="`echo "$URL"| sed -e 's@${DISTRO_COMPAT_VERSION}@'$DISTRO_COMPAT_VERSION'@g'`"
-                URL="`echo "$URL"| sed -e 's@${DDB_COMP}@'$DDB_COMP'@g'`"
-                URL="`echo "$URL"| sed -e 's@${SLACKWARE}@'$SLACKWARE'@g'`"
-                URL="`echo "$URL"| sed -e 's@${SLACKARCH}@'$SLACKARCH'@g'`"
-                URL="`echo "$URL"| sed -e 's@${lxDISTRO_COMPAT_VERSION}@'$lxDISTRO_COMPAT_VERSION'@g'`"
+                URL="$(echo "$URL"| sed -e 's@${DBIN_ARCH}@'$DBIN_ARCH'@g')"
+                URL="$(echo "$URL"| sed -e 's@${DISTRO_COMPAT_VERSION}@'$DISTRO_COMPAT_VERSION'@g')"
+                URL="$(echo "$URL"| sed -e 's@${DDB_COMP}@'$DDB_COMP'@g')"
+                URL="$(echo "$URL"| sed -e 's@${SLACKWARE}@'$SLACKWARE'@g')"
+                URL="$(echo "$URL"| sed -e 's@${SLACKARCH}@'$SLACKARCH'@g')"
+                URL="$(echo "$URL"| sed -e 's@${lxDISTRO_COMPAT_VERSION}@'$lxDISTRO_COMPAT_VERSION'@g')"
                 #ping -W2 -c1 -q $(echo  "${URL}" | awk -F/ '{print $3}') &>/dev/null
                 wget --quiet --timeout=2 --no-parent --spider "${URL}" &>/dev/null && \
                 {
@@ -4488,21 +4493,24 @@ pkg_download(){                   # download a pkg ($1) to WORKDIR FUNCLIST
             DOWNLOAD_URL="${DOWNLOAD_URL}${sub_dir}/"
 
             # add some system values into the repo URL (arch, distro version, etc.. from DISTRO_SPECS)
-            DOWNLOAD_URL="`echo "$DOWNLOAD_URL"| sed -e 's@${DBIN_ARCH}@'$DBIN_ARCH'@g'`"
-            DOWNLOAD_URL="`echo "$DOWNLOAD_URL"| sed -e 's@${DISTRO_COMPAT_VERSION}@'$DISTRO_COMPAT_VERSION'@g'`"
-            DOWNLOAD_URL="`echo "$DOWNLOAD_URL"| sed -e 's@${DDB_COMP}@'$DDB_COMP'@g'`"
-            DOWNLOAD_URL="`echo "$DOWNLOAD_URL"| sed -e 's@${SLACKWARE}@'$SLACKWARE'@g'`"
-            DOWNLOAD_URL="`echo "$DOWNLOAD_URL"| sed -e 's@${SLACKARCH}@'$SLACKARCH'@g'`"
-            DOWNLOAD_URL="`echo "$DOWNLOAD_URL"| sed -e 's@${lxDISTRO_COMPAT_VERSION}@'$lxDISTRO_COMPAT_VERSION'@g'`"
+            DOWNLOAD_URL="$(echo "$DOWNLOAD_URL"| sed -e 's@${DBIN_ARCH}@'$DBIN_ARCH'@g')"
+            DOWNLOAD_URL="$(echo "$DOWNLOAD_URL"| sed -e 's@${DISTRO_COMPAT_VERSION}@'$DISTRO_COMPAT_VERSION'@g')"
+            DOWNLOAD_URL="$(echo "$DOWNLOAD_URL"| sed -e 's@${DDB_COMP}@'$DDB_COMP'@g')"
+            DOWNLOAD_URL="$(echo "$DOWNLOAD_URL"| sed -e 's@${SLACKWARE}@'$SLACKWARE'@g')"
+            DOWNLOAD_URL="$(echo "$DOWNLOAD_URL"| sed -e 's@${SLACKARCH}@'$SLACKARCH'@g')"
+            DOWNLOAD_URL="$(echo "$DOWNLOAD_URL"| sed -e 's@${lxDISTRO_COMPAT_VERSION}@'$lxDISTRO_COMPAT_VERSION'@g')"
 
             # add our package to the URL
             DOWNLOAD_URL="${DOWNLOAD_URL}${PKG_FILENAME}"
 
             # remove any double forward slashes (the main URL or subdir may have ended in slashes, it may not, we added our own to be sure)
-            DOWNLOAD_URL="`echo "$DOWNLOAD_URL"| sed -e "s@//$PKG_FILENAME@/$PKG_FILENAME@g"`"
+            DOWNLOAD_URL="$(echo "$DOWNLOAD_URL"| sed -e "s@//$PKG_FILENAME@/$PKG_FILENAME@g")"
 
             # if sub_dir not empty, lets clean that bit too
-            [ "$sub_dir" != '' ] && DOWNLOAD_URL="`echo "$DOWNLOAD_URL"| sed -e "s@//${sub_dir}@/${sub_dir}@g" -e "s@${sub_dir}//@${sub_dir}/@g"`"
+            [ "$sub_dir" != '' ] && DOWNLOAD_URL="$(echo "$DOWNLOAD_URL" \
+              | sed \
+                -e "s@//${sub_dir}@/${sub_dir}@g" \
+                -e "s@${sub_dir}//@${sub_dir}/@g")"
 
             # exit if URL is not found (if we get a 404 back)
             if [ -z "$DOWNLOAD_URL" ]; then
@@ -4512,7 +4520,7 @@ pkg_download(){                   # download a pkg ($1) to WORKDIR FUNCLIST
               wget -S --spider "$DOWNLOAD_URL" &>/dev/null || \
               {
                 error "Package URL not found   $DOWNLOAD_URL"
-                return 8				  
+                return 8
               }
             fi
 
@@ -4520,14 +4528,14 @@ pkg_download(){                   # download a pkg ($1) to WORKDIR FUNCLIST
             #  remember the new one
             if [ "$OLDURL" != "$DOWNLOAD_URL" ];then
               OLDURL="$DOWNLOAD_URL";
-              #echo -e "URL: ${lightblue}${DOWNLOAD_URL}${endcolour}";
+              echo -e "URL: ${lightblue}${DOWNLOAD_URL}${endcolour}";
             fi
 
             # if --force, remove the package if it already exists
             [ "$FORCE" = true ] && rm -f "${WORKDIR}/${PKG_FILENAME}" &>/dev/null
 
             # if file not downloaded, or forcing downloads
-            if [ ! -f "${WORKDIR}/${PKG_FILENAME}" -o "$FORCE" = true ];then
+            if [ ! -f "${WORKDIR}/${PKG_FILENAME}" ] || [ "$FORCE" = true ];then
 
               # BEGIN DOWNLOAD file here..
 
@@ -4567,7 +4575,7 @@ pkg_download(){                   # download a pkg ($1) to WORKDIR FUNCLIST
             # clean up output
             [ "$QUIET" != true ] && echo -ne "\b\b\b\b"
             echo
-            ln -s "${PKG_FILENAME}" "$PKG_FNAME_GUESS" #TODO use relative symbolic links + symbolic link cleanup. 
+#            ln -s "${PKG_FILENAME}" "$PKG_FNAME_GUESS" 2>/dev/null #TODO use relative symbolic links + symbolic link cleanup.
             # if file downloaded ok
             if [ -f "${WORKDIR}/${PKG_FILENAME}" ];then
               echo -e "${green}Downloaded:${endcolour} ${WORKDIR}/${PKG_FILENAME}"
@@ -4619,10 +4627,10 @@ pkg_install(){                    # install downloaded package ($1) FUNCLIST
   . ${PKGRC}
 
   # exit if no valid option
-  [ ! "$1" -o "$1" = "-" ] && print_usage install && exit 1
+  [ ! "$1" ] || [ "$1" = "-" ] && print_usage install && exit 1
 
   # skip if not installing pkgs
-  [ "$NO_INSTALL" = true ] && continue
+  [ "$NO_INSTALL" = true ] && return 0
 
   local pkg_ext
   local PKGNAME
@@ -4632,57 +4640,57 @@ pkg_install(){                    # install downloaded package ($1) FUNCLIST
   local petspecs
 
   # get pkg extension
-  pkg_ext=`get_pkg_ext "$1"`
+  pkg_ext=$(get_pkg_ext "$1")
   # get pkg name only, no extension or path
   PKGNAME="$(basename "$1" .$pkg_ext)"
   # exit if no valid option
   [ "$PKGNAME" = '' ] && print_usage install && exit 1
   # get name without version
-  PKGNAME_ONLY=`get_pkg_name_only "$PKGNAME"`
+  PKGNAME_ONLY=$(get_pkg_name_only "$PKGNAME")
 
-  [ "`is_installed_pkg "$PKGNAME"`" = true -a "$FORCE" = false ] && echo "Already installed: $PKGNAME" && return 1
-  [ "`is_blacklisted_pkg "$PKGNAME_ONLY"`" = true ] && echo "Blacklisted package: $PKGNAME" && return 1
+  [ "$(is_installed_pkg "$PKGNAME")" = true ] && [ "$FORCE" = false ] && echo "Already installed: $PKGNAME" && return 1
+  [ "$(is_blacklisted_pkg "$PKGNAME_ONLY")" = true ] && echo "Blacklisted package: $PKGNAME" && return 1
 
   if [ -f "$1" ];then
     PKGFILE="$1"
-    PKGNAME=`basename "$1" .$pkg_ext`
+    PKGNAME=$(basename "$1" .$pkg_ext)
   else
     # get the real file name (inc path) from the given PKGFILE and pkg_ext (which may be empty)
-    PKGFILE=`find "$CURDIR" -mount -maxdepth 1 -type f -name "${PKGNAME}*${pkg_ext}" | head -1`
-    [ ! -f "$PKGFILE" ] && PKGFILE=`find "$CURDIR" -mount -maxdepth 1 -type f -name "${PKGNAME}*${EX}" | grep -m1 $EX`
-    [ -f "$PKGFILE" ] && PKGNAME=`basename "$1" .$pkg_ext`
+    PKGFILE=$(find "$CURDIR" -mount -maxdepth 1 -type f -name "${PKGNAME}*${pkg_ext}" | head -1)
+    [ ! -f "$PKGFILE" ] && PKGFILE=$(find "$CURDIR" -mount -maxdepth 1 -type f -name "${PKGNAME}*${EX}" | grep -m1 $EX)
+    [ -f "$PKGFILE" ] && PKGNAME=$(basename "$1" .$pkg_ext)
   fi
 
   # maybe the file is not in the current dir, but in WORKDIR, so lets look there too
   if [ ! -f "$PKGFILE" ];then
-    PKGFILE=`find "$WORKDIR" -mount -maxdepth 1 -type f -name "${PKGNAME}*${pkg_ext}" | head -1`
-    [ ! -f "$PKGFILE" ] && PKGFILE=`find "$WORKDIR" -mount -maxdepth 1 -type f -name "${PKGNAME}*${EX}" | grep -m1 $EX`
+    PKGFILE=$(find "$WORKDIR" -mount -maxdepth 1 -type f -name "${PKGNAME}*${pkg_ext}" | head -1)
+    [ ! -f "$PKGFILE" ] && PKGFILE=$(find "$WORKDIR" -mount -maxdepth 1 -type f -name "${PKGNAME}*${EX}" | grep -m1 $EX)
 
     # if we found the file in WORKDIR, make that our CURDIR
     if [ -f "$PKGFILE" ];then
-      PKGNAME=`basename "$PKGFILE" .$pkg_ext`
+      PKGNAME=$(basename "$PKGFILE" .$pkg_ext)
       CURDIR="$WORKDIR"
-      cd "$WORKDIR"
+      cd "$WORKDIR" || exit 1
     else
       # if we still didn't find it, do a broader check
-      PKGFILE=`find "$WORKDIR" -mount -maxdepth 1 -type f -name "${PKGNAME}*" | head -1`
+      PKGFILE=$(find "$WORKDIR" -mount -maxdepth 1 -type f -name "${PKGNAME}*" | head -1)
       if [ -f "$PKGFILE" ];then
-        PKGNAME=`basename "$PKGFILE" .$pkg_ext`
+        PKGNAME=$(basename "$PKGFILE" .$pkg_ext)
         CURDIR="$WORKDIR"
-        cd "$WORKDIR"
+        cd "$WORKDIR" || exit 1
       fi
     fi
   fi
 
   # if the file exists, or using --force
-  if [ -f "$PKGFILE" -o "$FORCE" = true ];then
+  if [ -f "$PKGFILE" ] || [ "$FORCE" = true ];then
 
     [ ! -f "$PKGFILE" ] && echo "The file $1 was not found." && return 1
 
     # get the extension of this newly found pkg (which we should have found by now)
-    pkg_ext=`get_pkg_ext "$PKGFILE"`
+    pkg_ext=$(get_pkg_ext "$PKGFILE")
     # get extension again, we may have been given only a pkg name, find its extension from repo files
-    [ "$pkg_ext" = "" ] && pkg_ext=`get_pkg_ext "$PKGNAME"`
+    [ "$pkg_ext" = "" ] && pkg_ext=$(get_pkg_ext "$PKGNAME")
 
     [ "$pkg_ext" = '' ] && echo "Not installing $PKGFILE." && error "Invalid file extension ($pkg_ext)." && return 1
 
@@ -4692,7 +4700,7 @@ pkg_install(){                    # install downloaded package ($1) FUNCLIST
     # if pkg is not yet installed, or we are force re-installing
 
     # get filename from download file
-    PKGNAME=`basename "$PKGFILE" .$pkg_ext`
+    PKGNAME=$(basename "$PKGFILE" .$pkg_ext)
 
     # ask/inform user before install
     echo -n "Install package ${PKGNAME}$QTAG:  "
@@ -4725,7 +4733,7 @@ pkg_install(){                    # install downloaded package ($1) FUNCLIST
         pet) # needs tar 1.26+
           rmdir "${CURDIR}/${PKGNAME}" &>/dev/null
           mkdir -p "${CURDIR}/${PKGNAME}"
-          PKGFILE="`find ${CURDIR} -mount -maxdepth 1 -type f -name "${PKGNAME}*.pet"`"
+          PKGFILE="$(find ${CURDIR} -mount -maxdepth 1 -type f -name "${PKGNAME}*.pet")"
           PETPKG=${PKGFILE%.pet} #remove trailing ".pet"
           head -c -32 ${PETPKG}.pet > ${PETPKG}.tar
           PETFILES="$(tar -tf ${PETPKG}.tar)"
@@ -4750,12 +4758,19 @@ pkg_install(){                    # install downloaded package ($1) FUNCLIST
           if [ -f "${CURDIR}/${PKGNAME}/puninstall.sh" ];then
             mv "${CURDIR}/${PKGNAME}/puninstall.sh" ${HOME}/.packages/${PKGNAME}.remove
           fi
-          echo "$PETFILES" | sed -e "$pPATTERN" -e "s#^\.\/#\/#g" -e "s#^#\/#g" -e "s#^\/\/#\/#g" -e 's#^\/$##g' -e 's#^\/\.$##g' > ${HOME}/.packages/${PKGNAME}.files
+          echo "$PETFILES" \
+            | sed \
+              -e "$pPATTERN" \
+              -e "s#^\.\/#\/#g" \
+              -e "s#^#\/#g" \
+              -e "s#^\/\/#\/#g" \
+              -e 's#^\/$##g' \
+              -e 's#^\/\.$##g' > ${HOME}/.packages/${PKGNAME}.files
         ;;
 
         sfs)
-          PKGFILE="`find ${CURDIR} -mount -maxdepth 1 -type f -name "${PKGNAME}*.sfs"`"
-          [ ! -f "$PKGFILE" ] && PKGFILE="`find ${WORKDIR} -mount -maxdepth 1 -type f -name "${PKGNAME}*.sfs"`"
+          PKGFILE="$(find ${CURDIR} -mount -maxdepth 1 -type f -name "${PKGNAME}*.sfs")"
+          [ ! -f "$PKGFILE" ] && PKGFILE="$(find ${WORKDIR} -mount -maxdepth 1 -type f -name "${PKGNAME}*.sfs")"
           echo sfs_load -q --cli +"$PKGFILE" #2>/dev/null
           sfs_load -q --cli +"$PKGFILE" #2>/dev/null
           rm -f $HOME/.packages/${PKGNAME}.files 2>/dev/null
@@ -4772,9 +4787,9 @@ pkg_install(){                    # install downloaded package ($1) FUNCLIST
 
           rmdir "${CURDIR}/${PKGNAME}" &>/dev/null
           mkdir -p "${CURDIR}/${PKGNAME}"
-          [ ! -f "$PKGFILE" ] && PKGFILE="`find ${CURDIR} -mount -maxdepth 1 -type f -name "${PKGNAME}*.deb"`"
+          [ ! -f "$PKGFILE" ] && PKGFILE="$(find ${CURDIR} -mount -maxdepth 1 -type f -name "${PKGNAME}*.deb")"
           cp "${PKGFILE}" "${CURDIR}/${PKGNAME}/${PKGNAME}.deb" || exit 4
-          cd "${CURDIR}/${PKGNAME}/"
+          cd "${CURDIR}/${PKGNAME}/" || exit 1
 
           if [ -f "${CURDIR}/${PKGNAME}/${PKGNAME}.deb" ];then
             dpkg-deb --contents "${CURDIR}/${PKGNAME}/${PKGNAME}.deb" \
@@ -4790,15 +4805,15 @@ pkg_install(){                    # install downloaded package ($1) FUNCLIST
           dpkg-deb -e "${CURDIR}/${PKGNAME}/${PKGNAME}.deb" /DEBIAN #130112 extracts deb control files to dir /DEBIAN. may have a post-install script, see below.
           rm "${PKGNAME}.deb"
 
-          cd - 1>/dev/null
+          cd - 1>/dev/null || exit 1
         ;;
 
         *tgz|*txz|*tzst|*tar.gz|*tar.xz|*tar.zst|*tlz|*tar.lzma|*tbz|*tar.bz2)
           rmdir "${CURDIR}/${PKGNAME}" &>/dev/null
           mkdir -p "${CURDIR}/${PKGNAME}"
-          PKGFILE="`find ${CURDIR} -mount -maxdepth 1 -type f -name "${PKGNAME}*.${pkg_ext}"`"
+          PKGFILE="$(find ${CURDIR} -mount -maxdepth 1 -type f -name "${PKGNAME}*.${pkg_ext}")"
           cp "$PKGFILE" "${CURDIR}/${PKGNAME}/${PKGNAME}.$pkg_ext" || exit 4
-          cd "${CURDIR}/${PKGNAME}/"
+          cd "${CURDIR}/${PKGNAME}/" || exit 1
           case "$pkg_ext" in
             *tbz|*tar.bz2)  bzip2 -dc "${PKGNAME}.$pkg_ext" | tar -xf - 2> $TMPDIR/$SELF-cp-errlog ;;
             *tlz|*tar.lzma) lzma -dc "${PKGNAME}.$pkg_ext"  | tar -xf - 2> $TMPDIR/$SELF-cp-errlog ;;
@@ -4806,14 +4821,14 @@ pkg_install(){                    # install downloaded package ($1) FUNCLIST
           esac
           tar -tf "${PKGNAME}.$pkg_ext" > $HOME/.packages/${PKGNAME}.files
           rm "${PKGNAME}.$pkg_ext"
-          cd - 1>/dev/null
+          cd - 1>/dev/null || exit 1
         ;;
 
         rpm)
-          PKGNAME="`basename ${PKGFILE} .rpm`"
+          PKGNAME="$(basename "${PKGFILE}" .rpm)"
           busybox rpm -qp "$PKGFILE" > /dev/null 2>&1
           [ $? -ne 0 ] && exit 1
-          PFILES="`busybox rpm -qpl $PKGFILE`"
+          PFILES="$(busybox rpm -qpl "$PKGFILE")"
           [ $? -ne 0 ] && exit 1
           echo "$PFILES" > $HOME/.packages/${PKGNAME}.files
           pkg_unpack "$PKGFILE" 1>/dev/null
@@ -4823,63 +4838,75 @@ pkg_install(){                    # install downloaded package ($1) FUNCLIST
 
       # now extract pkg contents to /
       [ ! -d "${PKGNAME}/" ] && error "Cannot enter directory '${PKGNAME}/', it doesn't exist." && exit 4
-      cd "${PKGNAME}/" 1>/dev/null
+      cd "${PKGNAME}/" 1>/dev/null || exit 1
 
-      cp -a --remove-destination * ${DIRECTSAVEPATH}/ 2> $TMPDIR/$SELF-cp-errlog
+      cp -a --remove-destination ./* ${DIRECTSAVEPATH}/ 2> $TMPDIR/$SELF-cp-errlog
 
       #source is a directory, target is a symlink...
       if [ -s $TMPDIR/$SELF-cp-errlog ];then
-        cat $TMPDIR/$SELF-cp-errlog  2>/dev/null | grep -E 'Cannot create symlink to|cannot overwrite non-directory' | cut -f 1 -d "'" | cut -f 2 -d '`' |
-        while read ONEDIRSYMLINK
-        do
-          #adding that extra trailing / does the trick...
-          cp -a --remove-destination ${ONEDIRSYMLINK}/* /${ONEDIRSYMLINK}/ 2> $TMPDIR/$SELF-cp-errlog #260713
-        done
+        grep -E 'Cannot create symlink to|cannot overwrite non-directory' $TMPDIR/$SELF-cp-errlog  2>/dev/null \
+          | cut -f 1 -d "'" \
+          | cut -f 2 -d '`' \
+          | while read ONEDIRSYMLINK
+            do
+              #adding that extra trailing / does the trick...
+              cp -a --remove-destination ${ONEDIRSYMLINK}/* /${ONEDIRSYMLINK}/ 2> $TMPDIR/$SELF-cp-errlog #260713
+            done
       fi
       sync
-      cd .. 1>/dev/null
+      cd .. 1>/dev/null || exit 1
 
       # move the *.files to $HOME/.packages
       FILES=''
-      FILES="`find "$CURDIR" -mount -maxdepth 1 -iname "*.files" | head -1`"
-      [ -f "`echo $FILES`" ] && mv "$FILES" "${HOME}/.packages/" 2>/dev/null #260713
+      FILES="$(find "$CURDIR" -mount -maxdepth 1 -iname "*.files" | head -1)"
+      [ -f "$FILES" ] && mv "$FILES" "${HOME}/.packages/" 2>/dev/null #260713
 
       #pkgname.files may need to be fixed...
-      cat ${HOME}/.packages/${PKGNAME}.files | grep -v '/$' \
-        | sed -e "s#^\.\/#\/#g" -e "s#^#\/#g" -e "s#^\/\/#\/#g" -e 's#^\/$##g' -e 's#^\/\.$##g' -e '\%^/install/%d' \
+      grep -v '/$' ${HOME}/.packages/${PKGNAME}.files \
+        | sed \
+          -e "s#^\.\/#\/#g"   \
+          -e "s#^#\/#g"       \
+          -e "s#^\/\/#\/#g"   \
+          -e 's#^\/$##g'      \
+          -e 's#^\/\.$##g'    \
+          -e '\%^/install/%d' \
         | sort -u > ${HOME}/.packages/${PKGNAME}.files2
-      mv ${HOME}/.packages/${PKGNAME}.files2 ${HOME}/.packages/${PKGNAME}.files
 
+      mv ${HOME}/.packages/${PKGNAME}.files2 ${HOME}/.packages/${PKGNAME}.files
       # some pets add images and icons at / so move them
       mv /{*.xpm,*.png,*.ico} /usr/share/pixmaps/ 2>/dev/null
 
       # run the post install scripts (for puppy, slackware, arch, debian/ubuntu, etc)
       for i in /pinstall.sh /install/doinst.sh /DEBIAN/postinst
       do
-        [ -z /${i} -o ! -e /${i} ] && continue
+        [ -z ${i} ] || [ ! -e /${i} ] && continue
         chmod +x /${i}
         cd /
         nohup sh ${i} &>/dev/null
         sleep 0.2
-        rm -f ${i}
-        cd ${CURDIR}/
+        rm -f ${i:-?}
+        cd ${CURDIR}/ || exit 1
       done
       rm -rf /install
       rm -rf /DEBIAN
 
       #130314 run arch linux pkg post-install script...
-      if [ -f /.INSTALL -a /usr/local/petget/ArchRunDotInstalls ];then #precaution. see 3builddistro, script created by noryb009.
+      #precaution. see 3builddistro, script created by noryb009.
+      if [ -f /.INSTALL ] && [ -f /usr/local/petget/ArchRunDotInstalls ];then 
         #this code is taken from below...
-        dlPATTERN='|'"`echo -n "${PKGNAME}" | sed -e 's%\\-%\\\\-%'`"'|'
-        archVER="`cat $TMPDIR/petget_missing_dbentries-Packages-* 2>/dev/null | grep "$dlPATTERN" | head -n 1 | cut -f 3 -d '|'`"
+        dlPATTERN='|'"$(echo -n "${PKGNAME}" | sed -e 's%\\-%\\\\-%')"'|'
+        archVER="$(cat $TMPDIR/petget_missing_dbentries-Packages-* 2>/dev/null \
+          | grep "$dlPATTERN" \
+          | head -n 1 \
+          | cut -f 3 -d '|')"
         if [ "$archVER" ];then #precaution.
           cd /
           mv -f .INSTALL .INSTALL1-${archVER}
           cp -a /usr/local/petget/ArchRunDotInstalls ArchRunDotInstalls
-          LANG=$LANG_USER ./ArchRunDotInstalls
+          LANG=$LANGUSER ./ArchRunDotInstalls
           rm -f ArchRunDotInstalls
           rm -f .INSTALL*
-          cd ${CURDIR}/
+          cd ${CURDIR}/ || exit 1
         fi
       fi
 
@@ -4893,21 +4920,21 @@ pkg_install(){                    # install downloaded package ($1) FUNCLIST
         cd /
 
         # get pkg info from pet.spec before we delete it, because the PET may not be a repo pkg
-        petspecs="`cat /pet.specs 2>/dev/null`"
+        petspecs="$(cat /pet.specs 2>/dev/null)"
 
         if [ "$petspecs" != '' ];then
           # now get pkg info
-          PKGCAT="`echo $petspecs|  cut -f5  -d'|'`"
-          PKGSIZE="`echo $petspecs| cut -f6  -d'|'`"
-          PKGDESC="`echo $petspecs| cut -f10 -d'|'`"
-          DEPSLIST="`echo $petspecs|cut -f9  -d'|'`"
+          PKGCAT="$(echo $petspecs|  cut -f5  -d'|')"
+          PKGSIZE="$(echo $petspecs| cut -f6  -d'|')"
+          PKGDESC="$(echo $petspecs| cut -f10 -d'|')"
+          DEPSLIST="$(echo $petspecs|cut -f9  -d'|')"
         fi
 
-        cd ${CURDIR}/
+        cd ${CURDIR}/ || exit 1
       fi
 
       # cleanup a bit
-      rm -R "${PKGNAME}/" 2>/dev/null || echo "${yellow}Warning:${endcolour} Cannot remove directory '${PKGNAME}/'." #150213
+      rm -R "${PKGNAME:-?}/" 2>/dev/null || echo "${yellow}Warning:${endcolour} Cannot remove directory '${PKGNAME}/'." #150213
 
       #flush unionfs cache, so files in pup_save layer will appear "on top"...
       if [ "$DIRECTSAVEPATH" != "" ];then
@@ -4916,12 +4943,12 @@ pkg_install(){                    # install downloaded package ($1) FUNCLIST
        find /initrd/pup_rw -mount -type f -name .wh.\*  -printf '/%P\n'|
        while read ONEWHITEOUT
        do
-        ONEWHITEOUTFILE="`basename "$ONEWHITEOUT"`"
-        ONEWHITEOUTPATH="`dirname "$ONEWHITEOUT"`"
-        ONEPATTERN="`echo -n "$ONEWHITEOUT" | sed -e 's%/\\.wh\\.%/%'`"'/*' ;#echo "$ONEPATTERN" >&2
-        [ "`grep -x "$ONEPATTERN" /root/.packages/${PKGNAME}.files`" != "" ] && rm -f "/initrd/pup_rw/$ONEWHITEOUT"
+        ONEPATTERN="$(echo -n "$ONEWHITEOUT" | sed -e 's%/\\.wh\\.%/%')"'/*' ;#echo "$ONEPATTERN" >&2
+        grep -q -x "$ONEPATTERN" /root/.packages/${PKGNAME}.files && rm -f "/initrd/pup_rw/$ONEWHITEOUT"
        done
-       #111229 /usr/local/petget/removepreview.sh when uninstalling a pkg, may have copied a file from sfs-layer to top, check...
+       # /usr/local/petget/removepreview.sh when uninstalling a pkg, 
+       # may have copied a file from sfs-layer to top, check...
+       # shellcheck disable=SC2002
        cat ${HOME}/.packages/${PKGNAME}.files |
        while read ONESPEC
        do
@@ -4937,28 +4964,28 @@ pkg_install(){                    # install downloaded package ($1) FUNCLIST
       fi
 
       # get pkg size, category and description
-      [ "$PKGCAT" = ''  ] && PKGCAT=`LANG=C  grep -m1 "|${PKGNAME_ONLY}|" "${HOME}/.packages/${REPOFILE}" 2>/dev/null | cut -f5 -d'|' | head -1`
-      [ "$PKGCAT" = ''  ] && PKGCAT=`LANG=C  grep -m1 "^${PKGNAME}|" "${HOME}/.packages/${REPOFILE}" 2>/dev/null | cut -f5 -d'|' | head -1`
-      [ "$PKGDESC" = '' ] && PKGDESC=`LANG=C grep -m1 "|${PKGNAME_ONLY}|" "${HOME}/.packages/${REPOFILE}" 2>/dev/null| cut -f10 -d'|' | head -1`
-      [ "$PKGDESC" = '' ] && PKGDESC=`LANG=C grep -m1 "^${PKGNAME}|" "${HOME}/.packages/${REPOFILE}" 2>/dev/null| cut -f10 -d'|' | head -1`
-      [ "$PKGSIZE" = '' ] && PKGSIZE=`LANG=C du -s -k ${CURDIR}/${PKG} 2>/dev/null | cut -f1`
+      [ "$PKGCAT" = ''  ] && PKGCAT=$(LANG=C  grep -m1 "|${PKGNAME_ONLY}|" "${HOME}/.packages/${REPOFILE}" 2>/dev/null | cut -f5 -d'|' | head -1)
+      [ "$PKGCAT" = ''  ] && PKGCAT=$(LANG=C  grep -m1 "^${PKGNAME}|" "${HOME}/.packages/${REPOFILE}" 2>/dev/null | cut -f5 -d'|' | head -1)
+      [ "$PKGDESC" = '' ] && PKGDESC=$(LANG=C grep -m1 "|${PKGNAME_ONLY}|" "${HOME}/.packages/${REPOFILE}" 2>/dev/null| cut -f10 -d'|' | head -1)
+      [ "$PKGDESC" = '' ] && PKGDESC=$(LANG=C grep -m1 "^${PKGNAME}|" "${HOME}/.packages/${REPOFILE}" 2>/dev/null| cut -f10 -d'|' | head -1)
+      [ "$PKGSIZE" = '' ] && PKGSIZE=$(LANG=C du -s -k ${CURDIR}/${PKG} 2>/dev/null | cut -f1)
       # get pkg version
-      PKGVER="`LANG=C  echo "$PKGNAME" | sed -e 's/^[^0-9]*-//g'`"
-      PKGARCH="`LANG=C echo "$PKGNAME" | cut -f3 -d'-' | grep -E 'i[3-9]|x[8-9]|arm64|armel|armhf|noarch'`"
+      PKGVER="$(get_pkg_version "$PKGNAME")"
+#      PKGARCH="`LANG=C echo "$PKGNAME" | cut -f3 -d'-' | grep -E 'i[3-9]|x[8-9]|arm64|armel|armhf|noarch'`"
 
       # last check for pkg info
-      [ "$DEPSLIST" = '' ] && DEPSLIST="`grep -m1 "^${PKGNAME}|" ${HOME}/.packages/Packages-* 2>/dev/null | cut -f9 -d'|' | grep '+' | head -1`"
+      [ "$DEPSLIST" = '' ] && DEPSLIST="$(grep -m1 "^${PKGNAME}|" ${HOME}/.packages/Packages-* 2>/dev/null | cut -f9 -d'|' | grep '+' | head -1)"
       [ "$PKGDESC" = ''  ] && PKGDESC="No description"
 
       #080917 - build woof compatible repo line .. #090817
-      if [ "`cut -f1 -d'|' ${HOME}/.packages/user-installed-packages 2>/dev/null | grep -m1 ^${PKGNAME}`" = '' ];then
+      if cut -f1 -d'|' ${HOME}/.packages/user-installed-packages 2>/dev/null | grep -q -m1 "^${PKGNAME}"; then
 
         # get the package db entry to add to user-installed-packages...
         # first, get it from petspecs if possible, or from the pkgs repo, or make one
         if [ -f /pet.specs ];then
-          DB_ENTRY="`cat /pet.specs | head -n 1`"
-        elif [ "`grep -m1 "^${PKGNAME}|" "${HOME}/.packages/$REPOFILE"`" != "" ];then
-          DB_ENTRY="`grep -m1 "^${PKGNAME}|" "${HOME}/.packages/$REPOFILE"`"
+          DB_ENTRY="$(head -n1 /pet.specs)"
+        elif grep -1 -m1 "^${PKGNAME}|" "${HOME}/.packages/$REPOFILE"; then
+          DB_ENTRY="$(grep -m1 "^${PKGNAME}|" "${HOME}/.packages/$REPOFILE")"
         else
           DB_ENTRY="${PKGNAME}|${PKGNAME_ONLY}|${PKGVER}|${BUILD}|${PKGCAT}|${PKGSIZE}|${PKGDIR}|${PKGNAME}.${pkg_ext}|${DEPSLIST}|${PKGDESC}|${DISTRO_BINARY_COMPAT}|${DISTRO_COMPAT_VERSION}"
         fi
@@ -4973,24 +5000,24 @@ pkg_install(){                    # install downloaded package ($1) FUNCLIST
       rm /*.pet.specs &>/dev/null
 
       # make sure /tmp has correct permission, a pkg may have overwritten it
+      # shellcheck disable=SC2010
       ls -dl /tmp | grep -q '^drwxrwxrwt' || chmod 1777 /tmp #130305 rerwin.
 
-      #090817
-      if [ "`is_installed_pkg $PKGNAME`" = true -a "`cat $HOME/.packages/${PKGNAME}.files`" != '' ];then
+      if [ "$(is_installed_pkg $PKGNAME)" = true ] && [ -s $HOME/.packages/${PKGNAME}.files ];then
         echo -e "${green}Installed:${endcolour} $PKGNAME"
         # show if pkg has menu entry
         menu_entry_msg "$PKGNAME_ONLY"
-        #080413 do fixmenus, if menu entry found #200713 moved here
-        if [ "`grep -m1 '/usr/share/applications' $HOME/.packages/${PKGNAME}.files 2>/dev/null | grep desktop$`" != "" ];then
+        # do fixmenus, if menu entry found
+        if grep -q -m1 '/usr/share/applications/.*.desktop' $HOME/.packages/${PKGNAME}.files 2>/dev/null; then
           [ ! -f /tmp/pkg/update_menus_busy ] && update_menus &
         fi
-        [ "`which logger`" != '' ] && logger "$0 Package $PKGNAME installed by $APP $APPVER"
+        [ "$(which logger)" != '' ] && logger "$0 Package $PKGNAME installed by $APP $APPVER"
       else
         error "$PKGNAME may not have installed correctly."
       fi
 
-      #100817 clean up user-installed-packages (remove duplicates and empty lines
-      cat ${HOME}/.packages/user-installed-packages | grep -v "^\$" | uniq > ${HOME}/.packages/user-installed-packages_clean
+      # clean up user-installed-packages (remove duplicates and empty lines, but DONT sort)
+      grep -v "^\$" ${HOME}/.packages/user-installed-packages | uniq > ${HOME}/.packages/user-installed-packages_clean
       mv ${HOME}/.packages/user-installed-packages_clean ${HOME}/.packages/user-installed-packages
 
       # puppy specific fixes for installed package
@@ -5007,17 +5034,17 @@ pkg_install(){                    # install downloaded package ($1) FUNCLIST
 
       echo "Package '$PKGNAME' not yet downloaded."
 
-      matching_local_pkgs="`list_downloaded_pkgs $PKGNAME`"
+      matching_local_pkgs="$(list_downloaded_pkgs $PKGNAME)"
 
       # if no matching pkgs downloaded
       if [ "$matching_local_pkgs" != "" ];then
         echo "You could install one of the following packages with \`$SELF -i PKGNAME\`:"
-        echo "`list_downloaded_pkgs $(basename "$PKGNAME" .$pkg_ext 2>/dev/null) 2>/dev/null`"
+        list_downloaded_pkgs "$(basename "$PKGNAME" .$pkg_ext 2>/dev/null)"
 
       # else if not downloaded, and in the current repo, list the matching repo pkgs
-      elif [ "$matching_local_pkgs" = "" -a "`grep -m1 "^${PKGNAME}|" "${HOME}/.packages/${REPOFILE}" 2>/dev/null`" != "" ];then
+      elif [ -z "$matching_local_pkgs" ] && grep -q -m1 "^${PKGNAME}|" "${HOME}/.packages/${REPOFILE}"; then
         echo "You must first download one of the following packages with \`$SELF -d PKGNAME\`:"
-        echo "`$PKGSEARCH $(basename $PKGNAME .$pkg_ext)`"
+        $PKGSEARCH "$(basename $PKGNAME .$pkg_ext 2>/dev/null)"
 
       else
         not_found "${PKGNAME}"
@@ -5034,7 +5061,7 @@ pkg_install(){                    # install downloaded package ($1) FUNCLIST
   fi
 
   # go back to the dir we started in
-  cd "$PREVDIR"
+  cd "$PREVDIR" || exit 1
 
 }
 
@@ -5044,7 +5071,7 @@ postinstall_hacks(){              # fix pkgs after installation
   local PKGNAME_ONLY="$2"
 
   # remove %u, %U, %f (etc) from Exec lines
-  DESKTOPFILE="`find /usr/share/applications -iname "${PKGNAME_ONLY}*.desktop"`"
+  DESKTOPFILE="$(find /usr/share/applications -iname "${PKGNAME_ONLY}*.desktop")"
   [ -f "$DESKTOPFILE" ] && \
     sed -i 's/ %u//' $DESKTOPFILE && \
     sed -i 's/ %U//' $DESKTOPFILE && \
@@ -5063,7 +5090,7 @@ postinstall_hacks(){              # fix pkgs after installation
     chmod 755 /usr/games/openclonk
    ;;
    vlc_*|vlc-*)
-    VLCDESKTOP="`find /usr/share/applications -mindepth 1 -maxdepth 1 -iname 'vlc*.desktop'`"
+    VLCDESKTOP="$(find /usr/share/applications -mindepth 1 -maxdepth 1 -iname 'vlc*.desktop')"
     [ -f $VLCDESKTOP ] && sed -i 's/ --started-from-file %U//' $VLCDESKTOP
     [ -f $VLCDESKTOP ] && sed -i 's/ --started-from-file//' $VLCDESKTOP
 
@@ -5077,23 +5104,23 @@ postinstall_hacks(){              # fix pkgs after installation
        chmod 755 /usr/bin/vlc
      fi
     fi
-   ;;
-   google-chrome-*) #130221 pemasu. 130224 pemasu: limit cache size...
+  ;;
+  google-chrome-*) #130221 pemasu. 130224 pemasu: limit cache size...
     if [ -f /usr/bin/bbe ];then #bbe is a sed-like utility for binary files.
-     if [ -f /opt/google/chrome/chrome  ];then
-    bbe -e 's/geteuid/getppid/' /opt/google/chrome/chrome > /tmp/chrome-temp1
-    mv -f /tmp/chrome-temp1 /opt/google/chrome/chrome
-    chmod 755 /opt/google/chrome/chrome
-    [ -e /usr/bin/google-chrome ] && rm -f /usr/bin/google-chrome
-    echo '#!/bin/sh
-  exec /opt/google/chrome/google-chrome --user-data-dir=/root/.config/chrome --disk-cache-size=10000000 --media-cache-size=10000000 "$@"' > /usr/bin/google-chrome
-    chmod 755 /usr/bin/google-chrome
-    ln -s google-chrome /usr/bin/chrome
-    ln -s /opt/google/chrome/product_logo_48.png /usr/share/pixmaps/google-chrome.png
-    ln -s /opt/google/chrome/product_logo_48.png /usr/share/pixmaps/chrome.png
-    CHROMEDESKTOP="`find /usr/share/applications -mindepth 1 -maxdepth 1 -iname '*chrome*.desktop'`"
-    if [ "$CHROMEDESKTOP" = "" ];then #precaution.
-     echo '[Desktop Entry]
+      if [ -f /opt/google/chrome/chrome  ];then
+        bbe -e 's/geteuid/getppid/' /opt/google/chrome/chrome > /tmp/chrome-temp1
+        mv -f /tmp/chrome-temp1 /opt/google/chrome/chrome
+        chmod 755 /opt/google/chrome/chrome
+        [ -e /usr/bin/google-chrome ] && rm -f /usr/bin/google-chrome
+        echo '#!/bin/sh
+        exec /opt/google/chrome/google-chrome --user-data-dir=/root/.config/chrome --disk-cache-size=10000000 --media-cache-size=10000000 "$@"' > /usr/bin/google-chrome
+        chmod 755 /usr/bin/google-chrome
+        ln -s google-chrome /usr/bin/chrome
+        ln -s /opt/google/chrome/product_logo_48.png /usr/share/pixmaps/google-chrome.png
+        ln -s /opt/google/chrome/product_logo_48.png /usr/share/pixmaps/chrome.png
+        CHROMEDESKTOP="$(find /usr/share/applications -mindepth 1 -maxdepth 1 -iname '*chrome*.desktop')"
+        if [ "$CHROMEDESKTOP" = "" ];then #precaution.
+          echo '[Desktop Entry]
 Encoding=UTF-8
 Version=1.0
 Name=Google Chrome web browser
@@ -5104,10 +5131,10 @@ Terminal=false
 Type=Application
 Icon=google-chrome.png
 Categories=WebBrowser;' > /usr/share/applications/google-chrome.desktop
+        fi
+      fi
     fi
-     fi
-    fi
-   ;;
+  ;;
   chromium*) #130221 pemasu. 130224 pemasu: limit cache size...
     if [ -f /usr/bin/bbe ];then #bbe is a sed-like utility for binary files.
      if [ -f /usr/lib/chromium/chromium  ];then
@@ -5224,10 +5251,10 @@ choose_pkg(){                     # given partial name ($1), choose from a list 
 
 
   # exit if no valid options
-  [ ! "$1" -o "$1" = "" -o "$1" = "-" ] && print_usage get && exit 1
+  [ ! "$1" ] || [ "$1" = "" ] || [ "$1" = "-" ] && print_usage get && exit 1
 
   # get $REPONAME and $EX
-  . ${PKGRC}
+  . "${PKGRC}"
 
   local REPOEX    # extension of pkgs in the current repo $REPONAME (from rc file)
   local PKGEX     # pkg extension we get from $1, defaults to $REPOEXT is empty
@@ -5235,10 +5262,11 @@ choose_pkg(){                     # given partial name ($1), choose from a list 
   local PKGNAME_ONLY  # the pkg name without version, we get this from PKGNAME
   local PKGS      # the list of PKGS returned matching $1/$PKGNAME
   local INT=1     # used to provide numbered lists
+  local sort      # set to either sort or sort -r
 
   REPOEX=$EX
   # get pkg extension
-  PKGEX=`get_pkg_ext "$1"`
+  PKGEX=$(get_pkg_ext "$1")
 
   # if no extension, set to extension of current repo
   [ "$PKGEX" = '' ] && PKGEX=$REPOEX
@@ -5247,10 +5275,10 @@ choose_pkg(){                     # given partial name ($1), choose from a list 
   PKGNAME="$(basename "$1" .$PKGEX)"
 
   # get the full pkg name, to compare against repo pkgs we find
-  PKGNAME_FULL="`get_pkg_name "$PKGNAME"`"
+  PKGNAME_FULL="$(get_pkg_name "$PKGNAME")"
 
   # get pkg name only .. without version or suffix
-  PKGNAME_ONLY=`get_pkg_name_only "$PKGNAME"`
+  PKGNAME_ONLY=$(get_pkg_name_only "$PKGNAME")
 
   # remove any previous user choice lists
   rm $TMPDIR/PKGLIST &>/dev/null
@@ -5258,32 +5286,36 @@ choose_pkg(){                     # given partial name ($1), choose from a list 
 
   # get all pkgs that match the given pkgname
   # returns full pkg names (field1 of repo, pkgname with ver but no extension) each on a new line
-  PKGS="`$PKGSEARCH "${PKGNAME}"`"
+  PKGS="$($PKGSEARCH "${PKGNAME}")"
 
-  if [ "$FORCE" = false -a "`is_installed_pkg "$PKGNAME_FULL"`" = true -a "$HIDE_INSTALLED" = true ];then
+  if [ "$FORCE" = false ] && [ "$(is_installed_pkg "$PKGNAME_FULL")" = true ] && [ "$HIDE_INSTALLED" = true ];then
     # remove it from choices
-    PKGS="`echo "$PKGS" | grep -v ^$PKGNAME_FULL\$`"
+    PKGS="$(echo "$PKGS" | grep -v ^$PKGNAME_FULL\$)"
   fi
 
   # extra steps for ubuntu and debian repos, if multiple choices returned.. remove non-compatible archs, remove dev and dbg pkgs...
-  if [ "$PKGEX" = "deb" -a "`echo "$PKGS" | wc -l`" != "1" ];then
+  if [ "$PKGEX" = "deb" ] && [ "$(echo "$PKGS" | wc -l)" != "1" ];then
 
-    ARCH="`uname -m`"
+    ARCH="$(uname -m)"
     #remove x64 pkgs from choices if not using an x64 cpu
-    [ "$ARCH" != "x86_64" ] && PKG="`echo "$PKGS" | grep -v -E 'amd64|x86_64'`"
+    [ "$ARCH" != "x86_64" ] && PKG="$(echo "$PKGS" | grep -v -E 'amd64|x86_64')"
 
-    # set any pkgs matching current arch to top of list
-    for LINE in `echo "$PKGS"  | sort -r` #first pkg found (newest) added to top, then the next, etc, sort use sort -r to keep newest at top of new list
+    # set any pkgs matching current arch to top of list:
+    # first pkg found (newest) added to top, then the next, etc, 
+    for LINE in $(echo "$PKGS"  | sort -r) 
     do
       # if not searching for -dev or -dgb pkg, move it to bottom of the list
-      if [ "`is_blacklisted_pkg "$(get_pkg_name_only "$LINE")"`" = false -a "`echo "$PKGNAME" | grep -E "\-dbg_|\-dev_"`" = "" -a "`echo "$LINE" | grep -E "\-dbg_|\-dev_"`" != "" ];then
-        PKGS="`echo "$PKGS" | grep -v  "$LINE"`"
+      if [ "$(is_blacklisted_pkg "$(get_pkg_name_only "$LINE")")" = false ] && \
+         [ "$(echo "$PKGNAME" | grep -E "\-dbg_|\-dev_")" = "" ] && \
+         [ "$(echo "$LINE" | grep -E "\-dbg_|\-dev_")" != "" ]
+      then
+        PKGS="$(echo "$PKGS" | grep -v  "$LINE")"
         PKGS="$PKGS
 $LINE"
       fi
       # if pkg is for current cpu arch, move it to top of the list
-      if [ "`echo "$LINE" | grep -m1 "$ARCH"`" != "" ];then
-        PKGS="`echo "$PKGS" | grep -v  "$LINE"`"
+      if [ "$(echo "$LINE" | grep -m1 "$ARCH")" != "" ];then
+        PKGS="$(echo "$PKGS" | grep -v  "$LINE")"
         PKGS="$LINE
 $PKGS"
       fi
@@ -5294,7 +5326,7 @@ $PKGS"
   fi
 
   # get the user to choose which packages they want to install
-  if [ "$ASK" = true -a "$PKGS" != "" ];then
+  if [ "$ASK" = true ] && [ "$PKGS" != "" ];then
     echo "Please choose the package number. For the first package,"
     echo "enter '1', without quotes. To install multiple packages,"
     echo "enter the numbers, separated by a comma. Example:  1,3,4"
@@ -5307,7 +5339,7 @@ $PKGS"
   # go through each actual pkg that matches the pkgname search, make it a numbered list
   echo "$PKGS" | $sort -u | while read LINE
   do
-    if [ "$LINE" != "" -a "$LINE" != "," -a "$LINE" != " " ];then
+    if [ "$LINE" != "" ] && [ "$LINE" != "," ] && [ "$LINE" != " " ];then
       [ "$ASK" = true ] && echo "${INT}. $LINE"
       echo "${INT}. $LINE" >> $TMPDIR/PKGLIST
       INT=$(($INT + 1))
@@ -5315,7 +5347,7 @@ $PKGS"
   done
 
   # if pkg list was made
-  if [ -f $TMPDIR/PKGLIST -a "`cat $TMPDIR/PKGLIST 2>/dev/null`" != "" ];then
+  if [ -f $TMPDIR/PKGLIST ] && [ -s "$TMPDIR/PKGLIST" ];then
 
     # set to first pkg only as default
     if [ "$ASK" = false ];then
@@ -5332,15 +5364,16 @@ $PKGS"
       echo "Give the numbers of the packages you want to install,"
       echo -n "separated by a comma, or hit ENTER only to skip: "
       read USRPKGLIST1 </dev/tty
+      echo
 
       # if user chose nothing (hit ENTER only), just skip
-      [ "$USRPKGLIST1" = '' ] && continue
+      [ "$USRPKGLIST1" = '' ] && exit 0
 
       # split the results into newlines, create the list of chosen pkgs (used by other funcs)
       echo "${USRPKGLIST1}" | tr ',' '\n' | while read LINE
       do
         # set chosen pkg choice(s)
-        echo "`grep "^$LINE. " "$TMPDIR/PKGLIST" 2>/dev/null | cut -f2 -d' '`" >> $TMPDIR/USRPKGLIST
+        grep "^$LINE. " "$TMPDIR/PKGLIST" 2>/dev/null | cut -f2 -d' ' >> $TMPDIR/USRPKGLIST
       done
     fi
 
@@ -5360,12 +5393,12 @@ pkg_get(){                        # find, download and install $1 and its deps F
   . ${PKGRC}
 
   # exit if no valid options
-  [ ! "$1" -o "$1" = "" -o "$1" = "-" ] && print_usage get && exit 1
+  [ ! "$1" ] || [ "$1" = "" ] || [ "$1" = "-" ] && print_usage get && exit 1
 
   local PREVDIR="$CURDIR"
-  local pkg_ext=`get_pkg_ext "$1"`; pkg_ext="${pkg_ext:-$EX}" # fall back to repo extension
-  local PKGNAME="`get_pkg_name $(basename "$1" .$pkg_ext)`"
-  local PKGNAME_ONLY=`get_pkg_name_only "$PKGNAME"`
+  local pkg_ext=$(get_pkg_ext "$1"); pkg_ext="${pkg_ext:-$EX}" # fall back to repo extension
+  local PKGNAME="$(get_pkg_name "$(basename "$1" .$pkg_ext)")"
+  local PKGNAME_ONLY=$(get_pkg_name_only "$PKGNAME")
   local PKGLIST="${PKGNAME}"
   local pkg_builtin=''
 
@@ -5373,15 +5406,15 @@ pkg_get(){                        # find, download and install $1 and its deps F
   ASK=false
 
   # exit if no valid pkg name
-  [ ! "$PKGNAME" -o "$PKGNAME" = "" -o "$PKGNAME" = "-" ] && print_usage get && exit 1
+  [ ! "$PKGNAME" ] || [ "$PKGNAME" = "" ] || [ "$PKGNAME" = "-" ] && print_usage get && exit 1
 
   # we want to download all pkgs to same place
-  cd "$WORKDIR"
+  cd "$WORKDIR" || exit 1
   CURDIR="$WORKDIR"
 
   # use the list of pkgs user has chosen to install, or the given PKGNAME
-  if [ -f $TMPDIR/USRPKGLIST ] && [ "`cat "$TMPDIR/USRPKGLIST" 2>/dev/null`" != "" ];then
-    PKGLIST="`cat "$TMPDIR/USRPKGLIST" | grep -v "^\$"`"
+  if [ -f $TMPDIR/USRPKGLIST ] && [ -s "$TMPDIR/USRPKGLIST" ];then
+    PKGLIST="$(grep -v "^\$" "$TMPDIR/USRPKGLIST")"
   fi
 
   if [ -z "$PKGLIST" ];then
@@ -5393,107 +5426,93 @@ pkg_get(){                        # find, download and install $1 and its deps F
   echo "$PKGLIST" | while read pkg
   do
 
-    [ "$pkg" = '' -o ! "$pkg" ] && continue
+    [ -z "$pkg" ] && continue
 
-    local pkg_name=`get_pkg_name "$pkg" 2>/dev/null`
-    [ "$pkg_name" = '' -o ! "$pkg_name" ] && continue
+    local pkg_name=$(get_pkg_name "$pkg" 2>/dev/null)
+    [ "$pkg_name" = '' ] || [ ! "$pkg_name" ] && continue
 
-    local pkg_name_only=`get_pkg_name_only "$pkg" 2>/dev/null`
-    [ "`is_blacklisted_pkg "$pkg_name_only"`" = true ] && continue
+    local pkg_name_only=$(get_pkg_name_only "$pkg" 2>/dev/null)
+    [ "$(is_blacklisted_pkg "$pkg_name_only")" = true ] && continue
 
-    local pkg_already_done=`grep -m1 "^$pkg_name_only\$" $TMPDIR/PKGSDONE 2>/dev/null`
+    local pkg_already_done=$(grep -m1 "^$pkg_name_only\$" $TMPDIR/PKGSDONE 2>/dev/null)
     [ "$pkg_already_done" != '' ] && continue
 
-    local pkg_in_repo=`is_repo_pkg $pkg_name_only`
+    local pkg_in_repo=$(is_repo_pkg "$pkg_name_only")
     local PKGFILE=''
 
     # dont even try to download if no matches found
-    if [ "$pkg_in_repo" = true -a "$pkg_name_only" != "" ];then
-
-      local pkg_is_builtin=`is_builtin_pkg "$pkg_name_only"`
-      local pkg_is_in_devx=`is_devx_pkg "$pkg_name_only"`
-
-      # skip getting pkg if its a builtin, unless HIDE_BUILTINS=false
-      if [ "$pkg_is_builtin" = true -a "${HIDE_BUILTINS}" = true ];then
-        echo "Skipping $pkg_name_only (already built-in).."
-        continue
-      fi
-
-      # skip getting pkg if its in the devx, unless HIDE_BUILTINS=false
-      if [ "$pkg_is_in_devx" = true -a "${HIDE_BUILTINS}" = true ];then
-        echo "Skipping $pkg_name_only (already in devx).."
-        continue
-      fi
-
-      # if we are intending to install the pkg
-      if [ "$NO_INSTALL" = false -a "$FORCE" = false ];then
-        # skip if package is already installed, unless --force given
-        if [ "$FORCE" = false -a "`is_installed_pkg $pkg_name`" = true ];then
-          echo -e "Package ${magenta}${pkg_name_only}${endcolour} already installed."
-          echo -e "Use the -f option to force installation: $SELF add $pkg_name_only -f"
-          continue
-        fi
-      fi
-
-      # get deps early (if any)
-      list_deps "$pkg_name" > ${TMPDIR}/${pkg_name}_dep_list &
-
-      # DOWNLOAD PKG
-      pkg_download "$pkg_name"
-
-      [ ! -f "$PKGFILE" ] && PKGFILE="`find "$CURDIR" -maxdepth 1 -type f -name "${pkg_name}.*${pkg_ext}"`"
-      # try grabbing $CURDIR/pkgname.pkg_ext
-      [ ! -f "$PKGFILE" ] && PKGFILE="`find "$CURDIR" -maxdepth 1 -type f -name "${pkg_name}*.${pkg_ext}"`"
-      # now try grabbing $CURDIR/pkgname.*
-      [ ! -f "$PKGFILE" ] && PKGFILE="`find "$CURDIR" -maxdepth 1 -type f -name "${pkg_name}.*"`"
-      # maybe try $CURDIR/pkgname-*.*
-      [ ! -f "$PKGFILE" ] && PKGFILE="`find "$CURDIR" -maxdepth 1 -type f -name "${pkg_name}-*.*"`"
-      # maybe try $CURDIR/pkgname_*.*
-      [ ! -f "$PKGFILE" ] && PKGFILE="`find "$CURDIR" -maxdepth 1 -type f -name "${pkg_name}_*.*"`"
-      # maybe try $CURDIR/pkgname*.*
-      [ ! -f "$PKGFILE" ] && PKGFILE="`find "$CURDIR" -maxdepth 1 -type f -name "${pkg_name}*.*"`"
-
-      if [ ! -f "$PKGFILE" ]; then
-        PKGFILE_symlink="`find "$CURDIR" -maxdepth 1 -type l -name "${pkg_name}*.*"`"
-        PKGFILE="$(readlink "$PKGFILE_symlink")"
-        rm "$PKGFILE_symlink"
-      fi
-      
-      # add extension if Pkg returned an erroneous or user dir
-      [ -d "$PKGFILE" ] && PKGFILE="${PKGFILE}.$pkg_ext"
-
-      # if we found the package to install in CURDIR
-      if [ -f "${PKGFILE}" ];then
-
-        # check if we install or not
-        if [ "${NO_INSTALL}" = false ];then
-
-          # if a valid pkg, with files to extract
-          if [ "`pkg_contents "$PKGFILE" 2>/dev/null`" != '' ];then
-
-
-            #INSTALL PKG
-            [ "`is_local_pkg "$PKGFILE"`" = true ] && pkg_install "${PKGFILE}"
-
-
-          fi
-
-        fi
-
-        # if pkg was installed, or Pkg is simply downloading all deps
-        if [ "`is_installed_pkg "$pkg_name_only"`" = true -o "${NO_INSTALL}" = true ];then
-
-          # get the dependencies for this package
-          get_deps "${pkg_name}"
-
-        fi
-
-      else # PKGFILE not a file
-        echo "Can't find ${PKGNAME} or not a valid pkg.."
-      fi
-
-    else # no matches in repo found
+    if [ "$pkg_in_repo" != true ] || [ "$pkg_name_only" = "" ];then
       echo "Cannot find ${PKGNAME}.."
+      continue
+    fi
+
+    # get deps early (if any)
+    list_deps "$pkg_name" > ${TMPDIR}/${pkg_name}_dep_list &
+
+    local pkg_is_builtin=$(is_builtin_pkg "$pkg_name_only")
+    local pkg_is_in_devx=$(is_devx_pkg "$pkg_name_only")
+
+    # skip getting pkg if its a builtin, unless HIDE_BUILTINS=false
+    if [ "$pkg_is_builtin" = true ] && [ "${HIDE_BUILTINS}" = true ];then
+      echo "Skipping $pkg_name_only (already built-in).."
+      continue
+    fi
+
+    # skip getting pkg if its in the devx, unless HIDE_BUILTINS=false
+    if [ "$pkg_is_in_devx" = true ] && [ "${HIDE_BUILTINS}" = true ];then
+      echo "Skipping $pkg_name_only (already in devx).."
+      continue
+    fi
+
+    # if we are intending to install the pkg
+    if [ "$NO_INSTALL" = false ] && [ "$FORCE" = false ];then
+      # skip if package is already installed, unless --force given
+      if [ "$FORCE" = false ] && [ "$(is_installed_pkg $pkg_name)" = true ];then
+        echo -e "Package ${magenta}${pkg_name_only}${endcolour} already installed."
+        echo -e "Use the -f option to force installation: $SELF add $pkg_name_only -f"
+        continue
+      fi
+    fi
+
+    # DOWNLOAD PKG
+    pkg_download "$pkg_name"
+
+    # now lets find the downloaded package
+    [ ! -f "$PKGFILE" ] && PKGFILE="$(find "$CURDIR" -maxdepth 1 -type f -name "$(get_pkg_filename "$pkg_name")")"
+
+    if [ ! -f "$PKGFILE" ]; then
+      PKGFILE_symlink="$(find "$CURDIR" -maxdepth 1 -type l -name "${pkg_name}*.*")"
+      PKGFILE="$(readlink "$PKGFILE_symlink")"
+      rm "$PKGFILE_symlink"
+    fi
+
+    # add extension if Pkg returned an erroneous or user dir
+    [ -d "$PKGFILE" ] && PKGFILE="${PKGFILE}.$pkg_ext"
+
+    if [ ! -f "${PKGFILE}" ];then
+      echo "Can't find ${PKGNAME} or not a valid pkg.."
+      continue
+    fi
+
+    # check if we install or not
+    if [ "${NO_INSTALL}" = false ];then
+
+      # if a valid pkg, with files to extract
+      #if [ "$(pkg_contents "$PKGFILE" 2>/dev/null)" != '' ];then
+
+        #INSTALL PKG
+        pkg_install "${PKGFILE}"
+
+      #fi
+
+    fi
+
+    # if pkg was installed, or Pkg is simply downloading all deps
+    if [ "$(is_installed_pkg "$pkg_name")" = true ] || [ "${NO_INSTALL}" = true ];then
+
+      # get the dependencies for this package
+      [ "$(has_deps $pkg_name)" = true ] && get_deps "${pkg_name}"
+
     fi
 
     # done with this pkg, add it to done list, will be skipped it seen again, until loop is finished
@@ -5505,37 +5524,35 @@ pkg_get(){                        # find, download and install $1 and its deps F
 pkg_update(){                     # update installed pkgs, $1 is optional filter FUNCLIST
 
   # exit if no valid options
-  #[ ! "$1" -o "$1" = "-" ] && print_usage pkg-update && exit 1
+  #[ ! "$1" ] || [ "$1" = "-" ] && print_usage pkg-update && exit 1
 
   # get rc file settings
-  . ${PKGRC}
+  . "${PKGRC}"
 
   local PKGNAME=''
   local PKGLIST=''
   local pkg_ext=$EX
-  local BUILTINS=''
-  local separator=''
 
   if [ "$1" != '' ];then
 
     PKGNAME=$(basename "$1")
-    PKGNAME=`get_pkg_name "$PKGNAME"`
-    PKGNAME_ONLY=`get_pkg_name_only "$PKGNAME"`
+    PKGNAME=$(get_pkg_name "$PKGNAME")
+    PKGNAME_ONLY=$(get_pkg_name_only "$PKGNAME")
 
     # get installed packages
-    PKGLIST="`HIDE_BUILTINS=true list_installed_pkgs "$PKGNAME_ONLY"`"
+    INSTALLED_PKG_LIST="$(HIDE_BUILTINS=true list_installed_pkgs "$PKGNAME_ONLY")"
 
     #is_builtin=`is_builtin_pkg "$PKGNAME"`
 
     # dont update builtins unless -F was given
-    #if [ "$is_builtin" = true -a "$HIDE_BUILTINS" = true ];then
+    #if [ "$is_builtin" = true ] && [ "$HIDE_BUILTINS" = true ];then
     #  echo -e "Package ${magenta}${PKGNAME}${endcolour} is built in, not updating."
     #  #echo -e "Use `$SELF -F --pkg-update $PKGNAME` to update it anyway."
     #  exit 0
     #fi
   else
     # get installed packages
-    PKGLIST="`HIDE_BUILTINS=true list_installed_pkgs`"
+    INSTALLED_PKG_LIST="$(HIDE_BUILTINS=true list_installed_pkgs)"
   fi
 
   # we don't want get_pkg to search this file, when it's called below,
@@ -5543,9 +5560,9 @@ pkg_update(){                     # update installed pkgs, $1 is optional filter
   rm -f $TMPDIR/USRPKGLIST 2>/dev/null
 
   # iterate over the list
-  echo "$PKGLIST"  | grep -v ^$ | sort -u | while read installed_pkg; do
+  echo "$INSTALLED_PKG_LIST"  | grep -v ^$ | sort -u | while read installed_pkg; do
 
-    [ ! "$installed_pkg" -o "$installed_pkg" = '' ] && continue
+    [ ! "$installed_pkg" ] || [ "$installed_pkg" = '' ] && continue
 
     # if this pkg ($installed_pkg) is not from a known repo, we cant compare its version to anything else, skip it
     #[ "`is_repo_pkg "$installed_pkg"`" = false ] && echo -e "Package ${magenta}$installed_pkg${endcolour} not found in any repos." && continue
@@ -5555,36 +5572,27 @@ pkg_update(){                     # update installed pkgs, $1 is optional filter
     local ASKREPLY='y'
     # get pkg name (without version) and version of current PKG
 
-    PNAME=`get_pkg_name_only $installed_pkg`
+    PNAME=$(get_pkg_name_only $installed_pkg)
 
     [ "$PNAME" = '' ] && continue
 
-    local pkg_is_blacklisted=`is_blacklisted_pkg "$PNAME"`
+    local pkg_is_blacklisted=$(is_blacklisted_pkg "$PNAME")
 
     # skip pkg if its a builtin
-    [ "$pkg_is_blacklisted" = true ] && return 1
+    [ "$pkg_is_blacklisted" = true ] && continue
 
-    case $DISTRO_BINARY_COMPAT in
-      ubuntu|trisquel|debian|devuan)
-        separator='_'
-        ;;
-      *)
-        separator='-'
-        ;;
-    esac
+    latest_repo_pkg="$(grep -m1 "^${PNAME}${separator}" ${HOME}/.packages/Packages-* |cut -f1 -d'|' | cut -f2 -d':')"
 
-    latest_repo_pkg="`grep -m1 "^${PNAME}${separator}" ${HOME}/.packages/Packages-* |cut -f1 -d'|' | head -1 | cut -f2 -d':'`"
+    # skip if we didn't find the right package (it might not be from a repo at all)_
+    [ "$(echo "$latest_repo_pkg" | grep "^${PNAME}${separator}")" = '' ] && continue
 
-    # skip if we didn't find the right package (it might from a repo at all)_
-    [ "`echo "$latest_repo_pkg" | grep "^${PNAME}${separator}"`" = '' ] && continue
-
-    latest_version=`get_pkg_version "$latest_repo_pkg"`
-    installed_version=`get_pkg_version "$installed_pkg"`
+    latest_version=$(get_pkg_version "$latest_repo_pkg")
+    installed_version=$(get_pkg_version "$installed_pkg")
 
     # get latest versions
 
     # check pkg version against installed version
-    if [ "$latest_version" != "" -a "$installed_version" != "" ];then
+    if [ "$latest_version" != "" ] && [ "$installed_version" != "" ];then
       vercmp $latest_version gt $installed_version 2>/dev/null
       RESULT=$?
 
@@ -5596,18 +5604,20 @@ pkg_update(){                     # update installed pkgs, $1 is optional filter
           [ "$ASK" = true ] && echo -ne "\b\b\n"
         fi
 
-        if [ "$ASK" = false -o "$ASKREPLY" = "y" ];then
-          (cd "$WORKDIR"
+        if [ "$ASK" = false ] || [ "$ASKREPLY" = "y" ];then
+          (
+          cd "$WORKDIR" || exit 1
           ASK=$ASK FORCE=$FORCE pkg_download "$latest_repo_pkg" &>/dev/null && \
           {
             FORCE=true pkg_uninstall "$installed_pkg" &>/dev/null && pkg_install "$latest_repo_pkg" &>/dev/null
             echo -e "${yellow}Updated${endcolour} ${magenta}$PNAME${endcolour} from ${bold}$installed_version${endcolour} to ${bold}$latest_version${endcolour}"
           } || pkg delete "$latest_repo_pkg" &>/dev/null
-          cd "$CURDIR")
+          cd "$CURDIR" || exit 1
+          )
         fi
 
       else #280613 inform user if no update found
-        echo -e "${green}Latest${endcolour}: $PNAME${separator}$installed_version"
+        echo -e "${green}Latest${endcolour}: $PNAME${separator}$latest_version"
       fi #end if vercmp XX gt YY = 0
 
     elif [ "$PNAME" = '' ];then
@@ -5623,15 +5633,16 @@ pkg_update(){                     # update installed pkgs, $1 is optional filter
 pkg_uninstall(){                  # remove an installed package ($1) FUNCLIST
 
   # quit if no valid options
-  [ ! "$1" -o "$1" = "-" ] && print_usage uninstall && exit 1
+  [ ! "$1" ] || [ "$1" = "-" ] && print_usage uninstall && exit 1
 
   local PKGNAME
   local PKGNAME_ONLY
   local PKGFILE
+  local PKGFILENAME
   local pkg_ext
 
   # get pkg extension
-  pkg_ext=`get_pkg_ext "$1"`
+  pkg_ext=$(get_pkg_ext "$1")
 
   #get pkg name with version, but no extension or path
   PKGNAME="$(basename "$1" .$pkg_ext)"
@@ -5642,42 +5653,41 @@ pkg_uninstall(){                  # remove an installed package ($1) FUNCLIST
   PKGNAME="$(basename "$PKGNAME" .tar.xz)"
   PKGNAME="$(basename "$PKGNAME" .tgz)"
   PKGNAME="$(basename "$PKGNAME" .txz)"
-  PKGNAME=`get_pkg_name "$PKGNAME"`
+  PKGNAME=$(get_pkg_name "$PKGNAME")
 
   # get pkg name only .. without versions or suffix
-  PKGNAME_ONLY="`get_pkg_name_only "$PKGNAME"`"
+  PKGNAME_ONLY="$(get_pkg_name_only "$PKGNAME")"
 
-  local pkg_is_blacklisted=`is_blacklisted_pkg "$PKGNAME_ONLY"`
+  local pkg_is_blacklisted=$(is_blacklisted_pkg "$PKGNAME_ONLY")
 
   # skip pkg if its a builtin
   [ "$pkg_is_blacklisted" = true ] && return 1
 
-  local pkg_is_builtin=`is_builtin_pkg "$PKGNAME_ONLY"`
+  local pkg_is_builtin=$(is_builtin_pkg "$PKGNAME_ONLY")
 
   # skip pkg if its a builtin
   [ "$pkg_is_builtin" = true ] && return 1
 
-  local is_installed=`is_installed_pkg "$PKGNAME"`
-
-  local pkg_is_sfs_file="`sfs_load -q -i | grep -v ^sfs_load | grep ^$PKGNAME`"
+  local pkg_is_sfs_file="$(sfs_load -q -i | grep -v ^sfs_load | grep ^$PKGNAME)"
 
   # if pkg is SFS, "uninstall" it here
-  if [ "$pkg_is_sfs_file" != "" -o "$pkg_ext" = "sfs" ];then
+  if [ "$pkg_is_sfs_file" != "" ] || [ "$pkg_ext" = "sfs" ];then
     PKGNAME="$(sfs_load -q -i | grep -v ^sfs_load | grep ^$PKGNAME | head -1)"
     sfs_load -q --cli -"${CURDIR}/${PKGNAME}" 2>/dev/null
     is_installed=true # we want to continue
   fi
 
+  local is_installed=$(is_installed_pkg "$PKGNAME")
 
-  if [ "$is_installed" = true -o "$FORCE" = true ];then #250713
+  if [ "$is_installed" = true ] || [ "$FORCE" = true ];then #250713
 
+    PKGFILENAME="$(get_pkg_filename "$PKGNAME")"
     # get the list of files to be deleted, exact match
-    PKGFILE="`find ${HOME}/.packages/ -maxdepth 1 -type f -name "$PKGNAME.files"`"
-
+    PKGFILE="$(find ${HOME}/.packages/ -maxdepth 1 -type f -name "$(basename "$PKGFILENAME" .$pkg_ext).files")"
     # if no exact match, search for pkgname*
-    [ ! -f "$PKGFILE" ] && PKGFILE="`find ${HOME}/.packages/ -maxdepth 1 -type f -name "${PKGNAME}*.files"`"
-    [ ! -f "$PKGFILE" ] && PKGFILE="`find ${HOME}/.packages/ -maxdepth 1 -type f -name "${PKGNAME_ONLY}_*.files"`"
-    [ ! -f "$PKGFILE" ] && PKGFILE="`find ${HOME}/.packages/ -maxdepth 1 -type f -name "${PKGNAME_ONLY}-*.files"`"
+    [ ! -f "$PKGFILE" ] && PKGFILE="$(find ${HOME}/.packages/ -maxdepth 1 -type f -name "${PKGNAME}*.files")"
+    [ ! -f "$PKGFILE" ] && PKGFILE="$(find ${HOME}/.packages/ -maxdepth 1 -type f -name "${PKGNAME_ONLY}_*.files")"
+    [ ! -f "$PKGFILE" ] && PKGFILE="$(find ${HOME}/.packages/ -maxdepth 1 -type f -name "${PKGNAME_ONLY}-*.files")"
     [ ! -f "$PKGFILE" ] && PKGFILE="${PKGNAME}.files"
     [ ! -f "$PKGFILE" ] && PKGFILE="${PKGNAME}.sfs.files"
     [ ! -f "$PKGFILE" ] && PKGFILE="${PKGNAME}-${CP_SUFFIX}.sfs.files"
@@ -5691,16 +5701,16 @@ pkg_uninstall(){                  # remove an installed package ($1) FUNCLIST
       cp ${HOME}/.packages/user-installed-packages $TMPDIR/user-installed-packages.backup
 
       # remove $PKGNAME from list of installed pkgs
-      cat ${HOME}/.packages/user-installed-packages 2>/dev/null | grep -v "^${PKGNAME}" > ${HOME}/.packages/user-installed-packages.updated
+      grep -v "^${PKGNAME}" ${HOME}/.packages/user-installed-packages 2>/dev/null > ${HOME}/.packages/user-installed-packages.updated
 
       # if we created a new file ok
       if [ -f ${HOME}/.packages/user-installed-packages.updated ];then
         # replace the user-installed-packages file with our new one
-        mv ${HOME}/.packages/user-installed-packages.updated ${HOME}/.packages/user-installed-packages 2>/dev/null
+        mv ${HOME}/.packages/user-installed-packages.updated ${HOME}/.packages/user-installed-packages
       fi
 
       # clean up user-installed-packages (remove duplicates and empty lines)
-      cat ${HOME}/.packages/user-installed-packages | grep -v "^\$" | uniq > ${HOME}/.packages/user-installed-packages.clean
+      grep -v "^\$" ${HOME}/.packages/user-installed-packages | uniq > ${HOME}/.packages/user-installed-packages.clean
       mv ${HOME}/.packages/user-installed-packages.clean ${HOME}/.packages/user-installed-packages
 
       # no *.files to process, so if not forcing full uninstall, we can exit here
@@ -5710,10 +5720,10 @@ pkg_uninstall(){                  # remove an installed package ($1) FUNCLIST
     # if we are here, we have a $HOME/.packages/***.files to work with (or using --force)
 
     # get pkgs that depend on $PKGNAME
-    [ "$FORCE" = false ] && dependents="`list_dependents "$PKGNAME"`" || dependents=''
+    [ "$FORCE" = false ] && dependents="$(list_dependents "$PKGNAME")" || dependents=''
 
     # if we have dependents, we should not uninstall and just exit, unless --force was given
-    if [ "$dependents" != "" -a "`echo "$dependents" | grep 'not installed'`" = '' -a "$FORCE" != true ];then
+    if [ ! -z "$dependents" ] && [ "$(echo "$dependents" | grep -m1 'not installed')" = '' ] && [ "$FORCE" != true ];then
 
       # inform user of dependent pkgs
       echo -e "${yellow}Warning${endcolour}: $PKGNAME_ONLY is needed by:  "
@@ -5749,7 +5759,7 @@ pkg_uninstall(){                  # remove an installed package ($1) FUNCLIST
       fi
 
       # check if has menu entry
-      [ "`cat "$PKGFILE" | grep -m1 ".desktop\$"`" != "" ] && HASMENUENTRY=true || HASMENUENTRY=false
+      grep -q -m1 ".desktop\$" "$PKGFILE" && HASMENUENTRY=true || HASMENUENTRY=false
 
       # remove files listed in *.files
       cat "$PKGFILE" | while read LINE
@@ -5769,8 +5779,8 @@ pkg_uninstall(){                  # remove an installed package ($1) FUNCLIST
               rm -f "$LINE" &>/dev/null
             fi
             #delete empty dirs...
-            DELDIR="`dirname "$LINE" 2>/dev/null`"
-            [ "`ls -1 "$DELDIR"`" = "" ] && rmdir "$DELDIR" &>/dev/null
+            DELDIR="$(dirname "$LINE" 2>/dev/null)"
+            [ "$(ls -1 "$DELDIR")" = "" ] && rmdir "$DELDIR" &>/dev/null
           fi
         fi
       done
@@ -5778,22 +5788,22 @@ pkg_uninstall(){                  # remove an installed package ($1) FUNCLIST
       # go through again and remove any empty dirs...
       cat "$PKGFILE" 2>/dev/null  | while read LINE
       do
-        DELDIR="`dirname "$LINE" 2>/dev/null`"
-        [ -d "$DELDIR" ] && [ "`ls -1 "$DELDIR"`" = "" ] && rmdir "$DELDIR"
+        DELDIR="$(dirname "$LINE" 2>/dev/null)"
+        [ -d "$DELDIR" ] && [ "$(ls -1 "$DELDIR")" = "" ] && rmdir "$DELDIR"
         #check one level up... but do not delete top dir, like /opt...
-        DELLEVELS=`echo -n "$DELDIR" | sed -e 's/[^/]//g' | wc -c | sed -e 's/ //g'`
+        DELLEVELS=$(echo -n "$DELDIR" | sed -e 's/[^/]//g' | wc -c | sed -e 's/ //g')
         if [ $DELLEVELS -gt 2 ];then
-          DELDIR="`dirname "$DELDIR" 2>/dev/null`"
-          [ -d "$DELDIR" ] && [ "`ls -1 "$DELDIR"`" = "" ] && rmdir $DELDIR
+          DELDIR="$(dirname "$DELDIR" 2>/dev/null)"
+          [ -d "$DELDIR" ] && [ "$(ls -1 "$DELDIR")" = "" ] && rmdir $DELDIR
         fi
       done
 
       # remove $PKGNAME from user-installed-packages
-      NEWUSERPKGS="`grep -v "^${PKGNAME}" ${HOME}/.packages/user-installed-packages`"
+      NEWUSERPKGS="$(grep -v "^${PKGNAME}" ${HOME}/.packages/user-installed-packages)"
       [ "$NEWUSERPKGS" != "" ] && echo "$NEWUSERPKGS" > ${HOME}/.packages/user-installed-packages
 
       # clean up user-installed-packages (remove duplicates and empty lines)
-      cat ${HOME}/.packages/user-installed-packages | grep -v "^\$" | uniq > ${HOME}/.packages/user-installed-packages_clean
+      grep -v "^\$" ${HOME}/.packages/user-installed-packages | uniq > ${HOME}/.packages/user-installed-packages_clean
       mv ${HOME}/.packages/user-installed-packages_clean ${HOME}/.packages/user-installed-packages
 
       # update system cache
@@ -5811,17 +5821,17 @@ pkg_uninstall(){                  # remove an installed package ($1) FUNCLIST
       echo -e "${green}Uninstalled:${endcolour} $PKGNAME"
 
       # log uninstall with the system logs
-      [ "`which logger`" != '' ] && logger "$0 Package $PKGNAME uninstalled by $APP $APPVER"
+      [ "$(which logger)" != '' ] && logger "$0 Package $PKGNAME uninstalled by $APP $APPVER"
 
     fi #end if $CONFIRM=yes
 
   else # $PKGNAME is not installed
 
     # if any installed pkg matches $PKGNAME
-    if [ "`list_installed_pkgs $PKGNAME`" != "" ];then #290613
+    if [ "$(list_installed_pkgs $PKGNAME)" != "" ];then #290613
       # list the matching pkgs
       echo "These installed packages match '$PKGNAME':"
-      echo "`list_installed_pkgs $PKGNAME`"
+      list_installed_pkgs "$PKGNAME"
     fi
 
     return 1
@@ -5833,7 +5843,7 @@ pkg_uninstall(){                  # remove an installed package ($1) FUNCLIST
 pkg_remove(){                     # remove pkg ($1) and its leftover deps FUNC_LIST
 
   # quit if no valid options
-  [ ! "$1" -o "$1" = "-" ] && print_usage remove && exit 1
+  [ ! "$1" ] || [ "$1" = "-" ] && print_usage remove && exit 1
 
   local PKGNAME
   local PKGNAME_ONLY
@@ -5841,16 +5851,16 @@ pkg_remove(){                     # remove pkg ($1) and its leftover deps FUNC_L
   local pkg_ext
 
   # get pkg extension
-  pkg_ext=`get_pkg_ext "$1"`
+  pkg_ext=$(get_pkg_ext "$1")
 
   #get pkg name with version, but no extension or path
   PKGNAME="$(basename "$1" .$pkg_ext)"
-  PKGNAME=`get_pkg_name "$PKGNAME"`
+  PKGNAME=$(get_pkg_name "$PKGNAME")
 
   # get pkg name only .. without versions or suffix
-  PKGNAME_ONLY="`get_pkg_name_only "$PKGNAME"`"
+  PKGNAME_ONLY="$(get_pkg_name_only "$PKGNAME")"
 
-  if [ "`is_installed_pkg "$PKGNAME"`" = false ];then
+  if [ "$(is_installed_pkg "$PKGNAME")" = false ];then
     echo "Package '$1' not installed."
     return 1
   fi
@@ -5859,7 +5869,7 @@ pkg_remove(){                     # remove pkg ($1) and its leftover deps FUNC_L
 
   # now we will remove any left over dependencies
 
-  file="`find $TMPDIR -iname "${1}*_dep_list"`"
+  file="$(find $TMPDIR -iname "${1}*_dep_list")"
 
   if [ -f "$file" ];then
 
@@ -5868,7 +5878,7 @@ pkg_remove(){                     # remove pkg ($1) and its leftover deps FUNC_L
 
     for x in 1 2 3 4
     do
-      cat "$file" | tr ' ' '\n' | while read user_installed_dep
+      tr ' ' '\n' "$file" | while read user_installed_dep
       do
         [ "$user_installed_dep" = '' ] && continue
         ASK=false pkg_uninstall $user_installed_dep &>/dev/null && \
@@ -5889,9 +5899,9 @@ clean_pkgs(){                     # delete downloaded pkg files of installed pkg
   list_installed_pkgs | while read line;
   do
     # get all pkgs except the combined (user-created) pkgs
-    pkg_to_rm="`list_downloaded_pkgs $line | grep -v $CP_SUFFIX`"
+    pkg_to_rm="$(list_downloaded_pkgs $line | grep -v $CP_SUFFIX)"
     # if it has a downloaded pkg in $WORKDIR, (offer to) delete it
-    [ "$pkg_to_rm" != '' ] && rm -v "${WORKDIR}/$pkg_to_rm";
+    [ "$pkg_to_rm" != '' ] && rm -v "${WORKDIR:-?}/$pkg_to_rm";
   done
 }
 
@@ -5899,17 +5909,17 @@ clean_pkgs(){                     # delete downloaded pkg files of installed pkg
 pkg_blacklist(){                  # give package name ($1) to "blacklist" (ignore) it
 
   # exit if no valid option
-  [ ! "$1" -o "$1" = "-" ] && print_usage blacklist && exit 1
+  [ ! "$1" ] || [ "$1" = "-" ] && print_usage blacklist && exit 1
 
   # skip if already in black list
   echo "$PKG_BLACKLIST" | grep -q -m1 "^${1}\$" && return 0
   # skip if its a builtin
   [ "$(is_builtin_pkg "$1")" = true ] && return 1
-  
+
   echo "$1" >> ~/.pkg/blacklisted_packages
   sort -u ~/.pkg/blacklisted_packages > ~/.pkg/blacklisted_packages__sorted
   mv ~/.pkg/blacklisted_packages__sorted ~/.pkg/blacklisted_packages
-  
+
   # regenerate the black list ($PKG_BLACKLIST)
   get_blacklist
 }
@@ -5918,8 +5928,8 @@ pkg_blacklist(){                  # give package name ($1) to "blacklist" (ignor
 pkg_whitelist(){                  # give package name ($1) to remove it from the "blacklist"
 
   # exit if no valid option
-  [ ! "$1" -o "$1" = "-" ] && print_usage whitelist && exit 1
-  
+  [ ! "$1" ] || [ "$1" = "-" ] && print_usage whitelist && exit 1
+
   grep -v "^${1}\$" ~/.pkg/blacklisted_packages > ~/.pkg/blacklisted_packages__sorted
   mv ~/.pkg/blacklisted_packages__sorted ~/.pkg/blacklisted_packages
 
@@ -5931,12 +5941,9 @@ pkg_whitelist(){                  # give package name ($1) to remove it from the
 # dependency funcs
 
 get_deps_entry(){                 # $1 is PKGNAME, returns dep entry from repo db
-  [ "$1" = '' -o "$1" = "-" ] && print_usage list-deps && exit 1
+  [ "$1" = '' ] || [ "$1" = "-" ] && print_usage list-deps && exit 1
 
-  # get current $REPOFILE, $DEPSEARCH
-  #. ${PKGRC}
-
-  local PKGNAME="$1"
+  local PKGNAME="$(get_pkg_name "$1")"
   local pkg_ext=''
   local repo_files=''
   local deps_list=''
@@ -5945,7 +5952,7 @@ get_deps_entry(){                 # $1 is PKGNAME, returns dep entry from repo d
   local repo_file_of_pkg=''
 
   # get pkg extension
-  pkg_ext=`get_pkg_ext "$1"`
+  pkg_ext=$(get_pkg_ext "$1")
 
 
   # get repo file to search from RC file
@@ -5955,9 +5962,9 @@ get_deps_entry(){                 # $1 is PKGNAME, returns dep entry from repo d
   if [ "$DEPSEARCH" = "list_all_pkg_names" ];then
 
     # get the repo that $PKGNAME lives in
-    repo_of_pkg=`which_repo "$PKGNAME" | cut -f2 -d' ' | head -1`
+    repo_of_pkg=$(which_repo "$PKGNAME" | cut -f2 -d' ' | head -1)
     # then get the repo file for that repo.. that is where this pkg lists its deps
-    repo_file_of_pkg=`grep -m1 ^"$repo_of_pkg" ~/.pkg/sources-all | cut -f3 -d'|'`
+    repo_file_of_pkg=$(grep -m1 ^"$repo_of_pkg" ~/.pkg/sources-all | cut -f3 -d'|')
 
   fi
 
@@ -5965,22 +5972,22 @@ get_deps_entry(){                 # $1 is PKGNAME, returns dep entry from repo d
   repo_file_of_pkg="$HOME/.packages/$repo_file_of_pkg"
 
   # search for deps entry in repo file.. look for |pkgname.ext|
-  deps_list="`LANG=C grep -m1 "|${PKGNAME}.$pkg_ext|" $repo_file_of_pkg 2>/dev/null | cut -f9 -d'|' | grep '+' | sed -e "s/:any//g" -e "s/&[geql][eqt][0-9a-z._-]*//g" | grep -vE '/ge|/le'`"
+  deps_list="$(LANG=C grep -m1 "|${PKGNAME}.$pkg_ext|" $repo_file_of_pkg 2>/dev/null)"
 
   # try again if needed.. look for ^pkgname|
-  [ "$deps_list" = "" -a "$PKGNAME" != '' ] && deps_list="`LANG=C grep -m1 "^${PKGNAME}|" $repo_file_of_pkg 2>/dev/null | cut -f9 -d'|' | grep '+' | sed -e "s/:any//g" -e "s/&[geql][eqt][0-9a-z._-]*//g" | grep -v '/ge'`"
+  [ "$deps_list" = "" ] && [ "$PKGNAME" != '' ] && deps_list="$(LANG=C grep -m1 "^${PKGNAME}|" $repo_file_of_pkg 2>/dev/null)"
 
   # try again if needed.. look for |pkgname|
-  [ "$deps_list" = "" -a "$PKGNAME" != '' ] && deps_list="`LANG=C grep -m1 "|${PKGNAME}|" $repo_file_of_pkg 2>/dev/null | cut -f9 -d'|' | grep '+' | sed -e "s/:any//g" -e "s/&[geql][eqt][0-9a-z._-]*//g" | grep -vE '/ge|/le'`"
+  [ "$deps_list" = "" ] && [ "$PKGNAME" != '' ] && deps_list="$(LANG=C grep -m1 "|${PKGNAME}|" $repo_file_of_pkg 2>/dev/null)"
 
   # try again, look for dep-*
-  [ "$deps_list" = "" -a "$PKGNAME" != '' ] && deps_list="`LANG=C grep -m1 "^${PKGNAME}-" $repo_file_of_pkg 2>/dev/null | cut -f9 -d'|' | grep '+' | sed -e "s/:any//g" -e "s/&[geql][eqt][0-9a-z._-]*//g" | grep -vE '/ge|/le'`"
+  [ "$deps_list" = "" ] && [ "$PKGNAME" != '' ] && deps_list="$(LANG=C grep -m1 "^${PKGNAME}-" $repo_file_of_pkg 2>/dev/null)"
 
   # try again if needed.. with underscore.. dep_*
-  [ "$deps_list" = "" -a "$PKGNAME" != '' ] && deps_list="`LANG=C grep -m1 "^${PKGNAME}_" $repo_file_of_pkg 2>/dev/null | cut -f9 -d'|' | grep '+' | sed -e "s/:any//g" -e "s/&[geql][eqt][0-9a-z._-]*//g" | grep -vE '/ge|/le'`"
+  [ "$deps_list" = "" ] && [ "$PKGNAME" != '' ] && deps_list="$(LANG=C grep -m1 "^${PKGNAME}_" $repo_file_of_pkg 2>/dev/null)"
 
   # if no deps, exit with error
-  [ "$deps_list" != "" ] && echo "$deps_list"
+  [ "$deps_list" != "" ] && echo "$deps_list" | cut -f9 -d'|' | grep '+' | sed -e "s/:any//g" -e "s/&[geql][eqt][0-9a-z._-]*//g" | grep -vE '/ge|/le'
 }
 
 
@@ -5988,7 +5995,7 @@ list_all_installed_pkgs(){        # list inc builtins if HIDE_BUILTINS=false
   # reset list of installed pkgs
   echo -n '' > $TMPDIR/installed_pkgs
 
-  if [ "${HIDE_INSTALLED}" = true -a "$FORCE" = false ];then
+  if [ "${HIDE_INSTALLED}" = true ] && [ "$FORCE" = false ];then
     # add user installed pkgs to list of pkgs to remove from final output
     cut -f2 -d'|' $HOME/.packages/user-installed-packages >> $TMPDIR/installed_pkgs
   fi
@@ -6008,7 +6015,7 @@ list_all_installed_pkgs(){        # list inc builtins if HIDE_BUILTINS=false
     cut -f2 -d'|' $HOME/.packages/layers-installed-packages >> $TMPDIR/installed_pkgs
   fi
 
-  if [ -f $TMPDIR/installed_pkgs -a ! -z $TMPDIR/installed_pkgs ];then
+  if [ -f $TMPDIR/installed_pkgs ] && [ -s $TMPDIR/installed_pkgs ];then
     sort -u $TMPDIR/installed_pkgs | grep -v ^$ > $TMPDIR/installed_pkgs__sorted
     mv $TMPDIR/installed_pkgs__sorted $TMPDIR/installed_pkgs
   fi
@@ -6016,13 +6023,13 @@ list_all_installed_pkgs(){        # list inc builtins if HIDE_BUILTINS=false
 
 
 has_deps(){                       # return true if $1 has deps, else false
-  [ "$1" = '' -o "$1" = "-" -o ! "$1" ] && echo false
-  [ "`get_deps_entry $1`" != '' ] && echo true || echo false
+  [ "$1" = '' ] || [ "$1" = "-" ] || [ ! "$1" ] && echo false
+  [ "$(get_deps_entry $1)" != '' ] && echo true || echo false
 }
 
 
 list_deps(){                      # list all deps of PKG ($1), space separated on one line FUNCLIST
-  [ "$1" = '' -o "$1" = "-" ] && print_usage list-deps && exit 1
+  [ "$1" = '' ] || [ "$1" = "-" ] && print_usage list-deps && exit 1
 
   echo true > /tmp/pkg/list_deps_busy
 
@@ -6042,17 +6049,16 @@ list_deps(){                      # list all deps of PKG ($1), space separated o
   local repo_file_of_pkg=''
 
   # get pkg extension
-  pkg_ext=`get_pkg_ext "$1"`
+  pkg_ext=$(get_pkg_ext "$1")
 
   #pkg name only ,no path, no extension
-  PKGNAME="$(LANG=C basename "$1" .$pkg_ext)"
-  PKGNAME=`get_pkg_name "$PKGNAME"`
-  PKGNAME_ONLY=`get_pkg_name_only "$PKGNAME"`
+  PKGNAME=$(get_pkg_name "$1")
+  PKGNAME_ONLY=$(get_pkg_name_only "$PKGNAME")
 
   # get the deps of the pkg, note, in the repo deps are NOT listed by proper pkg names, .. they are +dbus,+glib,+SDL
 
   # search for deps entry in repo file.. look for |pkgname.ext|
-  deps_list="`LANG=C get_deps_entry "$PKGNAME"`"
+  deps_list="$(LANG=C get_deps_entry "$PKGNAME")"
 
   # if no deps, exit with error
   [ "$deps_list" = "" ] && rm /tmp/pkg/list_deps_busy 2>/dev/null && return 1
@@ -6062,81 +6068,81 @@ list_deps(){                      # list all deps of PKG ($1), space separated o
   deps="${deps//,+/ }"   # remove others .. DEPS will now be just 'dep1 dep2 dep3'
   deps="${deps//  / }"   # remove double spaces
 
-  if [ "$deps" != '' -a "$deps" != ' ' ];then
+  if [ "$deps" != '' ] && [ "$deps" != ' ' ];then
 
     # put all deps of pkg in a tmp file
-    echo "$deps" | tr ' ' '\n' | tr ',' '\n' | sort -u > $TMPDIR/all_deps_0
-
-    # remove any deps in installed pkgs list from all deps.. to leave only missing deps
-    comm -23 ${TMPDIR}/all_deps_0 ${TMPDIR}/installed_pkgs | sort -u | grep -v ^$ > ${TMPDIR}/all_deps_1
+    echo "${deps// /,}" | tr ',' '\n' | grep -v ^$ | sort -u > $TMPDIR/all_deps_0
 
     grep -vE "'$PKG_BLACKLIST_REGEX'" ${TMPDIR}/all_deps_1 2>/dev/null | sort -u > ${TMPDIR}/all_deps_1_without_blacklisted_packages
     mv ${TMPDIR}/all_deps_1_without_blacklisted_packages ${TMPDIR}/all_deps_1
 
+    # remove any deps in installed pkgs list from all deps.. to leave only missing deps
+    comm -23 ${TMPDIR}/all_deps_0 ${TMPDIR}/installed_pkgs 2>/dev/null | grep -v ^$ | sort -u > ${TMPDIR}/all_deps_1
+
     rm -f ${TMPDIR}/DEP_DONE 2>/dev/null
 
-    if [ -f $TMPDIR/all_deps_1 -a ! -z $TMPDIR/all_deps_1 ];then
+    if [ -f $TMPDIR/all_deps_1 ] && [ -s $TMPDIR/all_deps_1 ];then
       # recursive search deps of deps
       for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15
       do
         deps_list_file="${TMPDIR}/all_deps_${i}"
 
 
-        if [ -f $deps_list_file ];then
+        [ ! -f $deps_list_file ] && continue
 
-          # remove all blacklisted packages from the list
-          grep -vE "'$PKG_BLACKLIST_REGEX'" "$deps_list_file" > ${TMPDIR}/deps_list_file_without_blacklisted_pkgs
-          mv ${TMPDIR}/deps_list_file_without_blacklisted_pkgs  $deps_list_file
+        # remove all blacklisted packages from the list
+        grep -vE "'$PKG_BLACKLIST_REGEX'" "$deps_list_file" > ${TMPDIR}/deps_list_file_without_blacklisted_pkgs
+        mv ${TMPDIR}/deps_list_file_without_blacklisted_pkgs  $deps_list_file
 
-          # remove done packages from the list
-          if [ -f ${TMPDIR}/DEP_DONE ];then
-            deps_done_list="$(cat ${TMPDIR}/DEP_DONE | tr '\n' '|' | grep -v ^$)"
-            grep -vE "'$deps_done_list'" $deps_list_file > ${TMPDIR}/deps_list_file_without_completed_pkgs
-            mv ${TMPDIR}/deps_list_file_without_completed_pkgs $deps_list_file
+        # remove done packages from the list
+        if [ -f ${TMPDIR}/DEP_DONE ];then
+          # shellcheck disable=SC2002
+          deps_done_regex="$(cat ${TMPDIR}/DEP_DONE | tr '\n' '|' | grep -v ^$ | sed -e 's/^|//g' -e 's/|$//g')"
+          grep -vE "'$deps_done_regex'" $deps_list_file > ${TMPDIR}/deps_list_file_without_completed_pkgs
+          mv ${TMPDIR}/deps_list_file_without_completed_pkgs $deps_list_file
+        fi
+
+        next_deps_list_file="${TMPDIR}/all_deps_$(($i + 1))"
+
+        # for each dep in $deps, get their deps too
+        for subdep in $(sort -u $deps_list_file | grep -v ^$)
+        do
+          [ "$subdep" = '' ] || [ "$subdep" = ' ' ] && continue
+
+          local subdeps_entry=''
+          local subdeps=''
+          local subdeps_list=''
+          local is_builtin
+          local is_in_devx
+
+          grep -q -m1 "^${subdep}\$" ${TMPDIR}/DEP_DONE 2>/dev/null && continue
+
+          if [ "$HIDE_BUILTINS" = true ];then
+            is_builtin=$(is_builtin_pkg "$subdep")
+            [ "$is_builtin" = true ] && continue
+            is_in_devx=$(is_devx_pkg "$subdep")
+            [ "$is_in_devx" = true ] && continue
           fi
 
-          next_deps_list_file="${TMPDIR}/all_deps_$(($i + 1))"
+          subdeps_entry="$(get_deps_entry "$subdep")"
+          subdeps="${subdeps_entry/+/}" # remove first + at start of line
+          subdeps="${subdeps//,+/ }"    # remove others .. DEPS will now be just 'dep1 dep2 dep3'
+          subdeps="${subdeps//  / }"    # remove double spaces
 
-          # for each dep in $deps, get their deps too
-          for subdep in `sort -u $deps_list_file | grep -v ^$`
-          do
-            [ "$subdep" = '' -o "$subdep" = ' ' ] && continue
+          if [ "$subdeps" != '' ] && [ "$subdeps" != ' ' ];then
+            # remove everything after the + (if the + is followed by alphanumeric chars), then add to tmp files
+            echo "$subdep" >> ${TMPDIR}/DEP_DONE
 
-            local subdeps_entry=''
-            local subdeps=''
-            local subdeps_list=''
-            local is_builtin
-            local is_in_devx
+            # create the next deps list file to parse, containing the deps of this $subdep
+            subdeps_list="$(echo "${subdeps}" | tr ' ' '\n' | grep -v ^$ | sort -u)"
+            echo "$subdeps_list" >> $next_deps_list_file
+          fi
+        done
 
-            local already_done=`grep -m1 "^${subdep}\$" ${TMPDIR}/DEP_DONE 2>/dev/null`
-            [ "$already_done" != '' ] && continue
-
-            if [ "$HIDE_BUILTINS" = true ];then
-              is_builtin=`is_builtin_pkg "$subdep"`
-              [ "$is_builtin" = true ] && continue
-              is_in_devx=`is_devx_pkg "$subdep"`
-              [ "$is_in_devx" = true ] && continue
-            fi
-
-            subdeps_entry="`get_deps_entry "$subdep"`"
-            subdeps="${subdeps_entry/+/}" # remove first + at start of line
-            subdeps="${subdeps//,+/ }"    # remove others .. DEPS will now be just 'dep1 dep2 dep3'
-            subdeps="${subdeps//  / }"    # remove double spaces
-
-            if [ "$subdeps" != '' ] && [ "$subdeps" != ' ' ];then
-              # remove everything after the + (if the + is followed by alphanumeric chars), then add to tmp files
-              echo "$subdep" >> ${TMPDIR}/DEP_DONE
-
-              # create the next deps list file to parse, containing the deps of this $subdep
-              subdeps_list="`echo "${subdeps}" | tr ' ' '\n' | grep -v ^$ | sed -e 's/++/+++/g' -e 's/+[a-z0-9].*//g' | sort -u`"
-              echo "$subdeps_list" >> $next_deps_list_file
-            fi
-          done
-        fi
       done
 
       # add all deps together, sorted, duplicated removed
-      sort -u ${TMPDIR}/all_deps_* | grep -v ^$ > ${TMPDIR}/all_deps_sorted
+      cat ${TMPDIR}/all_deps_* | sort -u | grep -v ^$ > ${TMPDIR}/all_deps_sorted
       mv ${TMPDIR}/all_deps_sorted ${TMPDIR}/all_deps
 
     fi
@@ -6144,22 +6150,24 @@ list_deps(){                      # list all deps of PKG ($1), space separated o
   fi
 
   # remove any deps in installed pkgs list from all deps.. to leave only missing deps
-  if [ -f ${TMPDIR}/installed_pkgs -a ! -z  ${TMPDIR}/installed_pkgs ];then
-    comm -23 ${TMPDIR}/all_deps ${TMPDIR}/installed_pkgs | sort -u | grep -v ^$ > ${TMPDIR}/missing_deps
+  if [ -f ${TMPDIR}/installed_pkgs ] && [ -s  ${TMPDIR}/installed_pkgs ];then
+    comm -23 ${TMPDIR}/all_deps ${TMPDIR}/installed_pkgs 2>/dev/null | sort -u | grep -v ^$ > ${TMPDIR}/missing_deps
   fi
 
   # remove all blacklisted packages from the list
   grep -vE "'$PKG_BLACKLIST_REGEX'" ${TMPDIR}/missing_deps 2>/dev/null | sort -u > ${TMPDIR}/missing_deps_without_blacklisted_pkgs
   mv ${TMPDIR}/missing_deps_without_blacklisted_pkgs ${TMPDIR}/missing_deps
 
-  [ ! -f ${TMPDIR}/missing_deps -o -z ${TMPDIR}/missing_deps ] && rm /tmp/pkg/list_deps_busy 2>/dev/null && return 1
-  [ ! -f ${TMPDIR}/missing_deps ] && return 1
+  if [ ! -f ${TMPDIR}/missing_deps ] || [ ! -s ${TMPDIR}/missing_deps ];then
+    rm /tmp/pkg/list_deps_busy 2>/dev/null
+    return 1
+  fi
 
   # get fixed deps list
-  deps="`LANG=C sort -u ${TMPDIR}/missing_deps 2>/dev/null | tr ' ' '\n' | while read dep
+  deps="$(LANG=C sort -u ${TMPDIR}/missing_deps 2>/dev/null | tr ' ' '\n' | while read dep
   do
-    echo $(get_pkg_name_only "$dep")
-  done`"
+    get_pkg_name_only "$dep"
+  done)"
 
   [ "$deps" != "" ] && echo "$deps" | sed -e 's/^ //g' | tr ' ' '\n' | sort -u | tr '\n' ' '
 
@@ -6193,20 +6201,19 @@ find_deps(){                      # given a package name ($1), makes 2 lists: DE
   local deps_missing=''       # comma separated list of missing deps
   local deps_installed=''     # comma separated list of deps already installed
   local dep=''                # dep name scraped from deps_list, usually the same as dep_name_only
-  local dep_match=''          # used to find matches in the repo for $dep
   local dep_name_only=''      # short (generic) pkg name, no version (vlc,htop,etc)
   local dep_full_name=''      # pkg name with version (vlc-2.3.3-i686_s700, etc)
   local loading_indicator     # blank if only a few deps to parse, or .
 
   # get pkg extension
-  pkg_ext=`get_pkg_ext "$1"`
+  pkg_ext=$(get_pkg_ext "$1")
 
   # pkg name with version, but no path, no extension
   PKGNAME="$(basename "$1" .$pkg_ext)"
 
   # we can't rely on the user input, try to get the right pkg names
-  PKGNAME=`get_pkg_name "$PKGNAME"`       # vlc -> 'vlc-2.3-blah_etc
-  PKGNAME_ONLY=`get_pkg_name_only "$PKGNAME"`   # vlc-2.3-blah_etc -> vlc
+  PKGNAME=$(get_pkg_name "$PKGNAME")       # vlc -> 'vlc-2.3-blah_etc
+  PKGNAME_ONLY=$(get_pkg_name_only "$PKGNAME")   # vlc-2.3-blah_etc -> vlc
 
   # if PKGNAME still empty, we cant find its deps, move on
   [ -z "$PKGNAME" ] && return 1
@@ -6218,84 +6225,88 @@ find_deps(){                      # given a package name ($1), makes 2 lists: DE
 
   # loop through all repo files, or current repo only, depending on PKGSEARCH in RC file
   # add the full path to the file(s) while we are getting the list of repo files
-  [ "$DEPSEARCH" = "list_all_pkg_names" ] && repo_files="`repo_file_list | sed -e "s|^|$HOME/.packages/|g" | tr '\n' ' '`" || repo_files="$HOME/.packages/$REPOFILE"
+  repo_files="$HOME/.packages/$REPOFILE"
+  [ "$DEPSEARCH" = "list_all_pkg_names" ] && repo_files="$(repo_file_list | sed -e "s|^|$HOME/.packages/|g" | tr '\n' ' ')"
 
   # get the list of deps from the repo entry of this pkg
-  deps_list="`LANG=C list_deps "$PKGNAME"`"
+  deps_list="$(LANG=C list_deps "$PKGNAME")"
 
   # remove builtins from list unless HIDE_BUILTINS=false
   if [ "${HIDE_BUILTINS}" = true ];then
-    echo "$deps_list" | tr ' ' '\n'  | grep -v ^$ > ${TMPDIR}/all_deps
+    echo "${deps_list// /
+}" | grep -v ^$ | sort -u > ${TMPDIR}/all_deps
+
     # add woof pkgs to list of pkgs to remove from final output
-    cut -f2 -d'|' $HOME/.packages/woof-installed-packages | grep -v ^$ | sort -u >> $TMPDIR/installed_pkgs
+    cut -f2 -d'|' $HOME/.packages/woof-installed-packages | grep -v ^$ | sort -u >> $TMPDIR/installed_pkgs 
+
     # remove any deps in installed pkgs list from all deps.. to leave only missing deps
-
-    sort -u ${TMPDIR}/all_deps > ${TMPDIR}/all_deps_sorted
-    mv ${TMPDIR}/all_deps_sorted ${TMPDIR}/all_deps
-
-    sort -u ${TMPDIR}/installed_pkgs > ${TMPDIR}/installed_pkgs_sorted
-    mv ${TMPDIR}/installed_pkgs_sorted ${TMPDIR}/installed_pkgs
-
-    comm -23 ${TMPDIR}/all_deps ${TMPDIR}/installed_pkgs | grep -v ^$ > ${TMPDIR}/missing_deps
-    deps_list="`cat "${TMPDIR}/missing_deps" 2>/dev/null | grep -v ^$ | sort | tr '\n' ' ' `"
+    comm -23 ${TMPDIR}/all_deps ${TMPDIR}/installed_pkgs 2>/dev/null | grep -v ^$ | sort -u > ${TMPDIR}/missing_deps
+    deps_list="$(grep -v "^$" "${TMPDIR}/missing_deps")"
   fi
+
+  # exit if no deps to parse
+  [ "$deps_list" = '' ] && return 1
 
   # so now, $deps_list='dep1 dep2 dep3'
 
   # now get the deps list with each dep on its own line
-  deps_on_new_lines="`echo "$deps_list" | tr ' ' '\n'`"
-
-  # exit if no deps to parse
-  [ "$deps_on_new_lines" = '' ] && return 1
+  deps_on_new_lines="${deps_list// /
+}"
 
   # set a loading bar (appending dots....) if we have numerous deps to search
-  [ `echo "$deps_on_new_lines" | wc -l` -gt 4 ] && loading_indicator='.' || loading_indicator=''
+  [ $(echo "$deps_on_new_lines" | wc -l) -gt 4 ] && loading_indicator='.' || loading_indicator=''
 
   # now.. we go through ALL deps listed, and create a list for installed or not .. $dep will be 'gtkdialog3', for example
-  echo "$deps_on_new_lines" | grep -v ^$ | while read dep
+  for dep in $deps_list
   do
     # append dots as we go, like a loading spinner
     [ "$loading_indicator" = '.' ] && echo -n "$loading_indicator"
 
     # $dep is currently
-    dep_full_name=`get_pkg_name "$dep"`     #vlc-2.3.3-i586_s700
-    dep_name_only=`get_pkg_name_only "$dep"`  #vlc
-
-    # skip these non pkgs
-    [ "`is_repo_pkg "$dep_name_only"`" = false ] && continue
+    dep_full_name=$(get_pkg_name "$dep")     #vlc-2.3.3-i586_s700
+    dep_name_only=$dep  #vlc
 
     # if we added this dep to the list of PKGs already done, skip it
-    [ "`grep -m1 "^$dep_name_only\$" $TMPDIR/PKGSDONE 2>/dev/null`" != '' ] && continue
+    grep -q -m1 "^$dep_name_only\$" $TMPDIR/PKGSDONE 2>/dev/null && continue
+
+    # skip these non pkgs
+    [ "$(is_repo_pkg "$dep")" = false ] && continue
 
     # lets check if the $dep is installed or not
 
     # if dep was found in a repo and not installed, add to missing deps list
-    if [ "$FORCE"  = true -o "`is_installed_pkg "$dep_full_name"`" = false ];then
-      grep -m1 "^$dep_name_only\$" $TMPDIR/deps_missing 2>/dev/null || echo "$dep_name_only" | grep -v "^$PKGNAME" >> $TMPDIR/deps_missing
+    if [ "$FORCE"  = true ] || [ "$(is_installed_pkg "$dep_full_name")" = false ];then
+      grep -q -m1 "^$dep_name_only\$" $TMPDIR/deps_missing 2>/dev/null || \
+      { 
+        echo "$dep_name_only" | grep -v "^$PKGNAME" >> $TMPDIR/deps_missing
+      }
 
     else
       # else if the dep is already installed, add to installed deps list
-      grep -m1 "^$dep_name_only\$" $TMPDIR/deps_installed 2>/dev/null || echo "$dep_name_only" | grep -v "^$PKGNAME" >> $TMPDIR/deps_installed
+      grep -q -m1 "^$dep_name_only\$" $TMPDIR/deps_installed 2>/dev/null || \
+      {
+        echo "$dep_name_only" | grep -v "^$PKGNAME" >> $TMPDIR/deps_installed
+      }
     fi
 
     # clean up deps_installed, remove duplicates, etc
     if [ -f $TMPDIR/deps_installed ];then
-      cat $TMPDIR/deps_installed 2>/dev/null| sort -u >> $TMPDIR/deps_installed1
-      [ -f $TMPDIR/deps_installed1 ] && mv $TMPDIR/deps_installed1 $TMPDIR/deps_installed 2>/dev/null
+      sort -u $TMPDIR/deps_installed 2>/dev/null > $TMPDIR/deps_installed1
+      mv $TMPDIR/deps_installed1 $TMPDIR/deps_installed 2>/dev/null
     fi
 
   done # end of while $dep
 
   # make a comma separated list from newlines
-  deps_installed="`cat $TMPDIR/deps_installed 2>/dev/null | sort -u | tr '\n' ',' | sed -e 's/,,/,/' -e 's/,$//' -e 's/^,//'`"
-  deps_missing="`cat $TMPDIR/deps_missing 2>/dev/null | sort -u | tr '\n' ',' | sed -e 's/,,/,/' -e 's/,$//' -e 's/^,//'`"
+  deps_installed="$(sort -u $TMPDIR/deps_installed 2>/dev/null | tr '\n' ',' | sed -e 's/,,/,/' -e 's/,$//' -e 's/^,//')"
+  deps_missing="$(sort -u $TMPDIR/deps_missing 2>/dev/null | tr '\n' ',' | sed -e 's/,,/,/' -e 's/,$//' -e 's/^,//')"
 
   #120213, fixed, force all deps to be in the download list, if --force was given
   if [ "$FORCE" = true ];then
     # dont skip installed deps (except builtins.. handled elsewhere)
     if [ "$deps_installed" != "" ];then
       deps_missing="${deps_installed},${deps_missing}"
-      deps_missing="`echo "${deps_missing//,,/}" | sed -e 's/,$//' -e 's/^,//'`"
+      deps_missing="$(echo "${deps_missing//,,/}" | sed -e 's/,$//' -e 's/^,//')"
     fi
   fi
 
@@ -6311,7 +6322,7 @@ find_deps(){                      # given a package name ($1), makes 2 lists: DE
 
 get_deps(){                       # find, get and install the deps of pkgname ($1) FUNCLIST
 
-  [ -z "$1" -o ! "$1" -o "$1" = "-" ] && print_usage deps && exit 1
+  [ -z "$1" ] || [ ! "$1" ] || [ "$1" = "-" ] && print_usage deps && exit 1
 
   . ${PKGRC} #150813
 
@@ -6320,28 +6331,26 @@ get_deps(){                       # find, get and install the deps of pkgname ($
   local DEPCONFIRM
 
   # get pkg extension
-  local EX=`get_pkg_ext "$1"`
+  local EX=$(get_pkg_ext "$1")
 
   # get pkg name with version, but no path, no extension
   local PKGNAME="$(LANG=C basename "$1" .$EX)"
 
   # don't rely on user input, get the name w version from repos
-  local PKGNAME=`get_pkg_name "$PKGNAME" 2>/dev/null`
-  local PKGNAME_ONLY=`get_pkg_name_only "$PKGNAME" 2>/dev/null`
-
-  local pkg_is_builtin=`is_builtin_pkg "$PKGNAME_ONLY" 2>/dev/null`
-  local pkg_already_done=`LANG=C grep -m1 "^$PKGNAME_ONLY\$" $TMPDIR/PKGSDONE 2>/dev/null`
-
-  local pkg_is_blacklisted=`is_blacklisted_pkg "$PKGNAME_ONLY" 2>/dev/null`
-
-  # if pkg is builtin, skip it, we dont need to get its dependencies
-  [ "$pkg_is_builtin" = true -a "$HIDE_BUILTINS" = true ] && continue
+  local PKGNAME=$(get_pkg_name "$PKGNAME" 2>/dev/null)
+  local PKGNAME_ONLY=$(get_pkg_name_only "$PKGNAME" 2>/dev/null)
 
   # if pkg is blacklisted, also skip it
-  [ "$pkg_is_blacklisted" = true ] && continue
+  local pkg_is_blacklisted=$(is_blacklisted_pkg "$PKGNAME_ONLY" 2>/dev/null)
+  [ "$pkg_is_blacklisted" = true ] && return
+
+  # if pkg is builtin, skip it, we dont need to get its dependencies
+  local pkg_is_builtin=$(is_builtin_pkg "$PKGNAME_ONLY" 2>/dev/null)
+  [ "$pkg_is_builtin" = true ] && [ "$HIDE_BUILTINS" = true ] && return
 
   # skip if already processed, it should be listed in $TMPDIR/PKGSDONE
-  [ "$pkg_already_done" != "" -a "$FORCE" = false ] && continue
+  local pkg_already_done=$(LANG=C grep -m1 "^$PKGNAME_ONLY\$" $TMPDIR/PKGSDONE 2>/dev/null)
+  [ "$pkg_already_done" != "" ] && [ "$FORCE" = false ] && return
 
   echo -n "Resolving dependencies.." # find deps will append ... as it goes
 
@@ -6354,10 +6363,14 @@ get_deps(){                       # find, get and install the deps of pkgname ($
   echo
 
   # if list_deps() created a file listing the deps, get it from the file created, else, run list deps to be sure
-  [ -f ${TMPDIR}/${pkg_name}_dep_list ] && DEPS_MISSING="`cat ${TMPDIR}/${pkg_name}_dep_list 2>/dev/null`" || DEPS_MISSING="`list_deps "$PKGNAME" 2>/dev/null`"
+  if [ -f ${TMPDIR}/${PKGNAME}_dep_list ];then
+    DEPS_MISSING="$(cat ${TMPDIR}/${PKGNAME}_dep_list 2>/dev/null)"
+  else 
+    DEPS_MISSING="$(list_deps "$PKGNAME" 2>/dev/null)"
+  fi
 
   # if we have missing deps, or are downloading them all regardless (INSTALLDEPS=false), or using --force
-  if [ "$DEPS_MISSING" != "" -o "${NO_INSTALL}" = true -o "$FORCE" = true ];then
+  if [ "$DEPS_MISSING" != "" ] || [ "${NO_INSTALL}" = true ] || [ "$FORCE" = true ];then
 
     # ask to download (and maybe install) the deps
     DEPCONFIRM=y
@@ -6371,66 +6384,65 @@ get_deps(){                       # find, get and install the deps of pkgname ($
     fi
 
     # if user answered yes, we will now download (and maybe install) the deps
-    if [ "$DEPCONFIRM" = "y" -o "$FORCE" = true ];then
+    if [ "$DEPCONFIRM" = "y" ] || [ "$FORCE" = true ];then
 
       # only ask once
       ASK=false
 
       # make a list of the deps, each on a new line for each dep/newline
-      WARNLIBS=''; SEP='';
-
-      # if more than one missing dep, set separator to a comma
-      [ ! -z "$DEPS_MISSING" -a "`echo "$DEPS_MISSING" | wc -l`" != "1" -a "`echo "$DEPS_MISSING" | wc -l`" != "0" ] && SEP=','
+      WARNLIBS='';
 
       # clean up our deps list, and make space separated only (no commas)
-      DEPS_MISSING="`LANG=C echo "${DEPS_MISSING//,/ }" | grep -v '^,' | grep -v "^\$"`"
+      DEPS_MISSING="${DEPS_MISSING//,/ }"
 
       # show deps info, if any available
       [ "${DEPS_MISSING}" != ""  ]   && echo "Dependencies to get: ${DEPS_MISSING//,/, }"
-      [ "$FORCE" = false -a "${DEPS_INSTALLED}" != "" ] && echo "Dependencies installed: `LANG=C grep -v "^\$" $TMPDIR/deps_installed 2>/dev/null | head -1`"
+      [ "$FORCE" = false ] && [ "${DEPS_INSTALLED}" != "" ] \
+        && echo "Dependencies installed: $(LANG=C grep -v "^\$" $TMPDIR/deps_installed 2>/dev/null | head -1)"
 
       # for each missing dep  (or simply for each dep, if $FORCE is true)
-      for DEP in $DEPS_MISSING
+      for DEP in ${DEPS_MISSING//,/ }
       do
 
-        [ "$DEP" = "" -o "$DEP" = "${PKGNAME_ONLY}" -o "$DEP" = "${PKGNAME}" ] && continue #skip if the dep is the main package
+        #skip if the dep is the main package
+        [ "$DEP" = "" ] || [ "$DEP" = "${PKGNAME_ONLY}" ] || [ "$DEP" = "${PKGNAME}" ] && continue 
 
-        local DEPNAME=`get_pkg_name "$DEP" 2>/dev/null`
-        local DEPNAME_ONLY=`get_pkg_name_only "$DEPNAME" 2>/dev/null`
+        local DEPNAME_ONLY="$DEP"
         local DEPFILE=''
 
-        # skip if already processed, it should be listed in $TMPDIR/PKGSDONE
-        local dep_already_done=`LANG=C grep -m1 "^$DEPNAME_ONLY\$" $TMPDIR/PKGSDONE 2>/dev/null`
-        [ "$dep_already_done" != "" -a "$FORCE" = false ] && continue
-
-        local dep_is_blacklisted=`is_blacklisted_pkg "$DEPNAME_ONLY" 2>/dev/null`
-        local dep_is_builtin=`is_builtin_pkg "$DEPNAME_ONLY" 2>/dev/null`
-        local dep_is_usr_pkg=`is_usr_pkg "$DEPNAME_ONLY" 2>/dev/null`
-        local dep_is_in_devx=`is_devx_pkg "$DEPNAME_ONLY" 2>/dev/null`
-
         # skip getting pkg if its blacklisted
+        local dep_is_blacklisted=$(is_blacklisted_pkg "$DEPNAME_ONLY" 2>/dev/null)
         if [ "$dep_is_blacklisted" = true ];then
           echo "Skipping $DEPNAME_ONLY (blacklisted).."
           continue
         fi
 
         # skip getting pkg if its a builtin, unless HIDE_BUILTINS=false
-        if [ "$dep_is_builtin" = true -a "${HIDE_BUILTINS}" = true ];then
+        local dep_is_builtin=$(is_builtin_pkg "$DEPNAME_ONLY" 2>/dev/null)
+        if [ "$dep_is_builtin" = true ] && [ "${HIDE_BUILTINS}" = true ];then
           echo "Skipping $DEPNAME_ONLY (already built-in).."
           continue
         fi
 
+        # skip if already processed, it should be listed in $TMPDIR/PKGSDONE
+        local dep_already_done=$(LANG=C grep -m1 "^$DEPNAME_ONLY\$" $TMPDIR/PKGSDONE 2>/dev/null)
+        [ "$dep_already_done" != "" ] && [ "$FORCE" = false ] && continue
+
         # skip getting pkg if its user installed and not using --force
-        if [ "$dep_is_usr_pkg" = true -a "${FORCE}" != true ];then
+        local dep_is_usr_pkg=$(is_usr_pkg "$DEPNAME_ONLY" 2>/dev/null)
+        if [ "$dep_is_usr_pkg" = true ] && [ "${FORCE}" != true ];then
           echo "Skipping $DEPNAME_ONLY (already installed).."
           continue
         fi
 
         # skip getting pkg if its in the devx, unless HIDE_BUILTINS=false
-        if [ "$dep_is_in_devx" = true -a "${HIDE_BUILTINS}" = true ];then
+        local dep_is_in_devx=$(is_devx_pkg "$DEPNAME_ONLY" 2>/dev/null)
+        if [ "$dep_is_in_devx" = true ] && [ "${HIDE_BUILTINS}" = true ];then
           echo "Skipping $DEPNAME_ONLY (already built-in).."
           continue
         fi
+
+        local DEPNAME=$(get_pkg_name "$DEP" 2>/dev/null)
 
         #DOWNLOAD THE PKG
         pkg_download "$DEPNAME" 2>/dev/null
@@ -6439,10 +6451,10 @@ get_deps(){                       # find, get and install the deps of pkgname ($
         if [ "${NO_INSTALL}" = false ];then
 
           # get the actual file we just downloaded to WORKDIR
-          DEPFILE="`find "$WORKDIR" -maxdepth 1 -type f -name "$DEPNAME*" 2>/dev/null`"
+          DEPFILE="$(find "$WORKDIR" -maxdepth 1 -type f -name "$DEPNAME*" 2>/dev/null)"
 
           #INSTALL THE DEP, if it was downloaded
-          [ "`is_local_pkg "$DEPFILE" 2>/dev/null`" = true ] && pkg_install "$DEPFILE" 2>/dev/null
+          [ "$(is_local_pkg "$DEPFILE" 2>/dev/null)" = true ] && pkg_install "$DEPFILE" 2>/dev/null
 
           # mark the pkg as done!
           echo "$DEPNAME_ONLY" >> $TMPDIR/PKGSDONE
@@ -6476,54 +6488,55 @@ get_deps(){                       # find, get and install the deps of pkgname ($
 pkg_ldd_msg(){                    # check given package ($1) for missing deps FUNCLIST
 
   # exit if no valid usage
-  [ ! "$1" -o "$1" = "-" ] && print_usage deps-check && exit 1
+  [ ! "$1" ] || [ "$1" = "-" ] && print_usage deps-check && exit 1
 
-  . ${PKGRC}
+  . "${PKGRC}"
 
   local PKGNAME
   local FNDFILES
-  local LIST
   local RES
   local MISSING
 
   # get pkg name
-  PKGNAME=`get_pkg_name "$1"`
+  PKGNAME=$(get_pkg_name "$1")
   rm $TMPDIR/pkg-$PKGNAME-MISSING.txt &>/dev/null
 
-  [ "`is_installed_pkg "$PKGNAME"`" = false ] && print_usage deps-check && exit 1
+  [ "$(is_installed_pkg "$PKGNAME")" = false ] && print_usage deps-check && exit 1
 
   echo "Searching for missing dependencies.. Please wait."
 
-  local list="$PKGNAME `list_deps $PKGNAME`"
+  local list="$PKGNAME $(list_deps $PKGNAME)"
 
   for pkg_name in $list
   do
-    local pkg_name_only=`get_pkg_name_only "$pkg_name"`
+    local pkg_name_only=$(get_pkg_name_only "$pkg_name")
     # get the *.files for this pkg
-    FNDFILES="`find $HOME/.packages/ -iname "${pkg_name}.files" 2>/dev/null`"
-    [ ! -f "$FNDFILES" ] && FNDFILES="`find $HOME/.packages/ -iname "${pkg_name}_*.files" 2>/dev/null`"
-    [ ! -f "$FNDFILES" ] && FNDFILES="`find $HOME/.packages/ -iname "${pkg_name}-*.files" 2>/dev/null`"
-    [ ! -f "$FNDFILES" ] && FNDFILES="`find $HOME/.packages/ -iname "${pkg_name}*.files"  2>/dev/null`"
+    FNDFILES="$(find $HOME/.packages/ -iname "${pkg_name}.files" 2>/dev/null)"
+    [ ! -f "$FNDFILES" ] && FNDFILES="$(find $HOME/.packages/ -iname "${pkg_name}_*.files" 2>/dev/null)"
+    [ ! -f "$FNDFILES" ] && FNDFILES="$(find $HOME/.packages/ -iname "${pkg_name}-*.files" 2>/dev/null)"
+    [ ! -f "$FNDFILES" ] && FNDFILES="$(find $HOME/.packages/ -iname "${pkg_name}*.files"  2>/dev/null)"
     [ ! -f "$FNDFILES" ] && continue
 
     # get list of ldd-able file
     cat "$FNDFILES" | grep -E '/lib/|/lib64/|/bin/|/games/|/sbin/' > ${TMPDIR}/ldd_file_list_${pkg_name}
-    [ -z ${TMPDIR}/ldd_file_list_${pkg_name} ] && continue
+    [ ! -s ${TMPDIR}/ldd_file_list_${pkg_name} ] && continue
 
     #loop through list
-    for file in `cat ${TMPDIR}/ldd_file_list_${pkg_name}`
+    for file in $(cat ${TMPDIR}/ldd_file_list_${pkg_name})
     do
       [ ! -x "$file" ] && continue
-      RES="`ldd $file 2>/dev/null`"
-      MISSING="`echo "$RES" | grep found`"
-      [ "$MISSING" != "" -a "$MISSING" != " " ] && echo "  $file:
+      RES="$(ldd $file 2>/dev/null)"
+      MISSING="$(echo "$RES" | grep found)"
+      if [ "$MISSING" != "" ] && [ "$MISSING" != " " ];then
+        echo "  $file:
   $MISSING" >> $TMPDIR/${pkg_name}-MISSINGLIBS.txt
+      fi
     done
 
     #print message
     if [ -f $TMPDIR/${pkg_name}-MISSINGLIBS.txt ];then
       echo -e "${yellow}WARNING${endcolour}: ${magenta}${pkg_name_only}${endcolour} has missing dependencies: "
-      echo -e "`cat $TMPDIR/${pkg_name}-MISSINGLIBS.txt`"
+      echo -e "$(cat $TMPDIR/${pkg_name}-MISSINGLIBS.txt)"
     else
       echo -e "${green}OK:${endcolour} ${pkg_name} has no missing dependencies."
     fi
@@ -6537,33 +6550,35 @@ get_all_deps(){                   # try to install all missing deps FUNCLIST
  rm $TMPDIR/pkg_get_all_deps 2>/dev/null
 
  list_installed_pkgs | while read LINE; do
-  DEPLIST="`LANG=C list_deps "$LINE"`"
-  [ "$DEPLIST" != "" -a "$LINE" != "" ] && echo "$LINE|$DEPLIST" >> $TMPDIR/pkg_get_all_deps
+  DEPLIST="$(LANG=C list_deps "$LINE")"
+  [ "$DEPLIST" != "" ] && [ "$LINE" != "" ] && echo "$LINE|$DEPLIST" >> $TMPDIR/pkg_get_all_deps
  done
 
- [ ! -f $TMPDIR/pkg_get_all_deps ]   && echo "No missing dependencies." && exit 0
- ASKOPT='';   [ "$ASK" = true ]   && ASKOPT='--ask ';
- FORCEOPT=''; [ "$FORCE" = true ] && FORCEOPT='--force ';
+ [ ! -f $TMPDIR/pkg_get_all_deps ] && echo "No missing dependencies." && exit 0
+
+ ASKOPT='';   [ "$ASK" = true   ] && export ASKOPT='--ask ';
+ FORCEOPT=''; [ "$FORCE" = true ] && export FORCEOPT='--force ';
 
  cat $TMPDIR/pkg_get_all_deps 2>/dev/null | while read LINE
  do
-  [ "$LINE" = "" -o "`echo "$LINE" | grep -v '|'`" = "" ] && continue
+  [ "$LINE" = "" ] || [ "$(echo "$LINE" | grep -v '|')" = "" ] && continue
   # get pkg gname from field 1
   PKGNAME="${LINE%%|*}"
   DEPS="${LINE##*|}"
 
   echo "Checking $PKGNAME..."
 
-  for DEP in $DEPS;
+  for DEP in $DEPS
   do
     # try to get the pkg name
-    DEPPKG="`list_all_pkg_names $DEP- | head -1`" || \
-    DEPPKG="`list_all_pkg_names $DEP_ | head -1`" || \
-    DEPPKG="`list_all_pkg_names $DEP  | head -1`"
+    DEPPKG="$(list_all_pkg_names $DEP-)" || \
+    DEPPKG="$(list_all_pkg_names $DEP_)" || \
+    DEPPKG="$(list_all_pkg_names $DEP)"
     # if dep not in any repos, skip it
     [ "$DEPPKG" = "" ] && continue
+    DEPPKG="$(echo "$DEPPKG" | head -1)"
     # skip if the dep is already installed
-    [ "`is_installed_pkg $DEPPKG`" = true ] && continue
+    [ "$(is_installed_pkg "$DEPPKG")" = true ] && continue
     # ask to get dep
     echo -n "Get the missing package: ${DEPPKG}$QTAG:  "
     echo
@@ -6590,11 +6605,11 @@ list_dependents(){                # list user installed pkgs that depend on $1 F
   fi
 
   # try to get correct pkg names
-  PKGNAME=`get_pkg_name "$1"`
-  PKGNAME_ONLY=`get_pkg_name_only "$1"`
+  PKGNAME=$(get_pkg_name "$1")
+  PKGNAME_ONLY=$(get_pkg_name_only "$1")
 
   # if pkg is not installed, then nothing depends on it
-  if [ "`is_installed_pkg "$PKGNAME"`" = false ];then
+  if [ "$(is_installed_pkg "$PKGNAME")" = false ];then
     echo "Package $1 not installed, nothing depends on it."
     exit 1
   fi
@@ -6603,39 +6618,37 @@ list_dependents(){                # list user installed pkgs that depend on $1 F
   cut -f1,2,9 -d'|' $HOME/.packages/Packages-* \
     | sed -e "s/:any//g" -e "s/&[geql][eqt][0-9a-z._-]*//g" 2>/dev/null \
     | grep -E "+${PKGNAME_ONLY},|+${PKGNAME_ONLY}\|" 2>/dev/null \
-    | cut -f2 -d'|' 2>/dev/null \
+    | cut -f2 -d'|' \
     | grep -v "^\$" \
-    | grep -v "^#" \
+    | grep -v "^#"  \
     | grep -v "^$PKGNAME_ONLY\$" \
     | sort -u \
-    >> ${TMPDIR}/dependents_list
+    > ${TMPDIR}/dependents_list_all
 
   if [ "$HIDE_BUILTINS" = false ];then
     # list all builtin and devx packages with $PKGNAME_ONLY as a dependency..
-    cut -f1,2,9 -d'|' $HOME/.packages/woof-installed-packages  $HOME/.packages/devx-installed-packages\
+    cut -f1,2,9 -d'|' $HOME/.packages/woof-installed-packages $HOME/.packages/devx-installed-packages \
       $HOME/.packages/devx-only-installed-packages \
       | grep -E "+${PKGNAME_ONLY},|+${PKGNAME_ONLY}\|" \
       | cut -f2 -d'|' \
       | grep -v "^\$" \
-      | grep -v "^#" \
+      | grep -v "^#"  \
       | grep -v "^$PKGNAME_ONLY\$" \
       | sort -u \
-      >> ${TMPDIR}/dependents_list
+      >> ${TMPDIR}/dependents_list_all
   fi
 
   # remove duplicates
-  sort -u ${TMPDIR}/dependents_list > ${TMPDIR}/dependents_list__sorted
-  mv ${TMPDIR}/dependents_list__sorted ${TMPDIR}/dependents_list_tmp
-  rm ${TMPDIR}/dependents_list
+  sort -u ${TMPDIR}/dependents_list_all | grep -v ^$ > ${TMPDIR}/dependents_list_all__sorted
+  mv ${TMPDIR}/dependents_list_all__sorted ${TMPDIR}/dependents_list_all
 
-  # only keep the user installed pkgs in the list
-  for pkg in `list_installed_pkgs | grep -v ^$PKGNAME`
-  do
-    [ "`grep -m1 "^$(get_pkg_name_only $pkg)\$" ${TMPDIR}/dependents_list_tmp`" != '' ] && echo "$pkg" >> ${TMPDIR}/dependents_list
-  done
+  # remove packages that are not installed
+  cut -f2 -d'|' $HOME/.packages/user-installed-packages | sort -u | grep -v ^$ > $TMPDIR/user-installed_sorted
+  comm -12 ${TMPDIR}/dependents_list_all $TMPDIR/user-installed_sorted | sort -u > ${TMPDIR}/dependents_list
 
   # print the list if we have one
-  [ -f ${TMPDIR}/dependents_list -a ! -z ${TMPDIR}/dependents_list ] && cat ${TMPDIR}/dependents_list
+  [ -f ${TMPDIR}/dependents_list ] && [ -s ${TMPDIR}/dependents_list ] && cat ${TMPDIR}/dependents_list
+  
   rm ${TMPDIR}/dependents_lis* 2>/dev/null
 }
 
@@ -6648,25 +6661,22 @@ deb2pet(){                        # $1 must be valid deb file or repo pkg FUNCLI
   local DEB="${CURDIR}/$(basename "${1}")"
   local DIRNAME="${CURDIR}"
   #create file name we work with
-  [ -f "$1" ] && DEB="$1" && DIRNAME="`dirname "$1"`"
+  [ -f "$1" ] && DEB="$1" && DIRNAME="$(dirname "$1")"
 
   #keep old file, download it if needed
   #[ -f "$(basename "$1" .deb)" ] || ASK=$ASK FORCE=$FORCE pkg_download "$(basename "$1" .deb)"
 
   # if the deb exists
   if [ -e "$DEB" ]; then
-    for i in "$DEB" # for each deb given
-    do
-      #remove the extensions
-      #example, will be something like FOLDR=$HOME/Desktop/atari800_3.1.0-2+b2_i386
-      FOLDR="$(echo "$i"|sed 's/\.deb$//')"
-    done
+    #remove the extensions
+    #example, will be something like FOLDR=$HOME/Desktop/atari800_3.1.0-2+b2_i386
+    FOLDR="$(echo "$DEB"|sed 's/\.deb$//')"
 
     #make the new dir, copy the deb file into it, and ci into it
     mkdir -p "$FOLDR"; cp "$DEB" "$FOLDR"; cd "$FOLDR";
 
     #get the new full path and filename
-    DEB="`ls | grep ".deb"`"
+    DEB="$(ls | grep ".deb")"
 
     # extract into current dir and remov ethe copied deb file
     pkg_unpack "$DEB" 1>/dev/null
@@ -6677,7 +6687,7 @@ deb2pet(){                        # $1 must be valid deb file or repo pkg FUNCLI
     #now we package up the stuff into a pet
     [ -d "${FOLDR}/$PKGNAME" ] && dir2pet "${FOLDR}/$PKGNAME" || dir2pet "$PKGNAME"
 
-    [ ! -f "$FOLDR.pet" -a ! -f "${CURDIR}/${PKGNAME}.pet" ] && error "$FOLDR.deb NOT converted to PET package!"
+    [ ! -f "$FOLDR.pet" ] && [ ! -f "${CURDIR}/${PKGNAME}.pet" ] && error "$FOLDR.deb NOT converted to PET package!"
 
     #clean up
     rm -rf "$FOLDR"
@@ -6823,7 +6833,7 @@ dir2pet(){                        # dir to PET, $1 must be valid dir FUNCLIST
     fi
 
     # if in a pre-woof puppy then we dont use xz
-    if [ ! -f ${HOME}/.packages/woof-installed-packages -o ! -f /etc/DISTRO_SPECS ];then
+    if [ ! -f ${HOME}/.packages/woof-installed-packages ] || [ ! -f /etc/DISTRO_SPECS ];then
       # pre woof format
       echo "PETMENUDESCR='${DIR}'" >  $CURDIR/build_pkg/${DIR}/${DIR}.pet.specs
       echo "PETOFFICIALDEPS=''"    >> $CURDIR/build_pkg/${DIR}/${DIR}.pet.specs
@@ -6888,7 +6898,7 @@ dir2sfs(){                        # $1 must be dir of pkg contents FUNCLIST
     echo "Please wait... building SFS file.."
     local SFS_NAME="${SFS_DIR/$SFS_SUFFIX/}${SFS_SUFFIX}.sfs"
     LANG=C mksquashfs "$SFS_DIR" "$SFS_NAME" -noappend &>/dev/null && SUCCESS="y" || SUCCESS=""
-    if [ -z "$SUCCESS" -a ! -f "${SFS_DIR}${SFS_SUFFIX}.sfs" ]; then
+    if [ -z "$SUCCESS" ] && [ ! -f "${SFS_DIR}${SFS_SUFFIX}.sfs" ]; then
       echo "Failed to create $SFS_NAME."
       exit 1
     fi
@@ -6981,10 +6991,10 @@ pet2sfs(){                        # convert pet to sfs, $1 must be file or repo 
   rm -f "${PKGNAME}.tar.$TAREXT"
 
   # if pkg put the pet in $CURDIR (not user), remove it
-  #[ -f "${PKGFILE}" -a "`dirname "$1"`" != "$CURDIR" ] && rm -f "${PKGFILE}" 2>/dev/null
+  #[ -f "${PKGFILE}" ] && [ "`dirname "$1"`" != "$CURDIR" ] && rm -f "${PKGFILE}" 2>/dev/null
 
   # print message
-  if [ ! -f "${PKGNAME}.sfs" -a ! -f "${PKGNAME}${SFS_SUFFIX}.sfs" ];then
+  if [ ! -f "${PKGNAME}.sfs" ] && [ ! -f "${PKGNAME}${SFS_SUFFIX}.sfs" ];then
     echo "Package '${PKGNAME}.pet' not converted."
     return 1
   fi
@@ -7067,7 +7077,7 @@ sfs2pet(){                        # convert sfs to pet, requires $1 as a valid s
   # build the file name we will work on
   SFS="${SFSDIR}/${SFSNAME}"
 
-  if [ -f "$SFS" -a "$SFS" != "" ];then
+  if [ -f "$SFS" ] && [ "$SFS" != "" ];then
 
     echo "Unsquashing $SFSNAME.. Please wait.."
 
@@ -7217,7 +7227,7 @@ txz2pet(){                        # convert txz to pet, requires $1 as valid fil
 menu_entry_msg(){                 # show menu entry details of installed pkg FUNCLIST
 
   # exit if not valid usage
-  [ ! "$1" -o "$1" = "-" ] && exit 1
+  [ ! "$1" ] || [ "$1" = "-" ] && exit 1
 
   . ${PKGRC}
 
@@ -7268,7 +7278,7 @@ menu_entry_msg(){                 # show menu entry details of installed pkg FUN
     #mv ${TMPDIR}/fixed.desktop $MENUFILE
 
     # print msg
-    if [ "$no_display" != "" -o "$terminal_only" != '' ];then
+    if [ "$no_display" != "" ] || [ "$terminal_only" != '' ];then
       pkg_command="`grep -m1 ^Exec= "$MENUFILE" | cut -f2 -d'='`"
       [ "$pkg_command" != '' ] && echo -e "To run, type:  ${bold}${pkg_command}${endcolour}"
     else
@@ -7285,7 +7295,7 @@ update_menus() {                  # update menus, calls fixmenus, refreshes WM
   echo started > /tmp/pkg/update_menus_busy
   fixmenus &>/dev/null
   # refresh JWM menus if using JWM window manager
-  [ "`which jwm`" != "" -a "`ps -e | grep jwm`" != "" ] && jwm -reload &>/dev/null
+  [ "`which jwm`" != "" ] && [ "`ps -e | grep jwm`" != "" ] && jwm -reload &>/dev/null
   rm /tmp/pkg/update_menus_busy 2>/dev/null
   return 0
 }
@@ -7293,7 +7303,7 @@ update_menus() {                  # update menus, calls fixmenus, refreshes WM
 
 check_net(){                      # check net connection (before downloading) FUNCLIST
   [ -f $TMPDIR/internetsuccess ] && echo 0 && exit 0 #220613
-  [ ! "$1" -o "$1" = "-" ] && URL="8.8.8.8" || URL="`echo  ${1} | awk -F/ '{print $3}'`"
+  [ ! "$1" ] || [ "$1" = "-" ] && URL="8.8.8.8" || URL="`echo  ${1} | awk -F/ '{print $3}'`"
   LANG=C ping -4 -c1 -q "$URL" &>/dev/null #220613
   REPLY=$?
   [ $REPLY -eq 0 ] && echo -n "ok" > $TMPDIR/internetsuccess #220613
@@ -7308,8 +7318,6 @@ get_stdin(){                      # read from stdin (when - is last option) FUNC
 
 not_found(){                      # list alternative packages when no match in repos FUNCLIST
   PKGNAME="${1/.pet/}"
-  #echo "$APPTITLE"
-  #echo "Package '${PKGNAME}' not found in current repo..  "
   if [ "$(ls "${WORKDIR}/"| grep "${PKGNAME}")" != "" ];then
     [ "`list_downloaded_pkgs "${PKGNAME}"`" != "" ] && echo "These downloaded packages match your search:
 `list_downloaded_pkgs "${PKGNAME}"`"
@@ -7385,7 +7393,7 @@ if [ ! -f "${HOME}/.packages/$REPOFILE" ];then
   [ ! -z "$REPOFILE" ] && touch "${HOME}/.packages/$REPOFILE"
 fi
 # try to set a default repo if none was found
-if [ ! -f "${HOME}/.packages/$REPOFILE" -o ! -f "$HOME/.pkg/sources" ];then
+if [ ! -f "${HOME}/.packages/$REPOFILE" ] || [ ! -f "$HOME/.pkg/sources" ];then
 
   mkdir -p $HOME/.pkg 2>/dev/null
   mkdir -p $HOME/.packages 2>/dev/null
@@ -7409,9 +7417,9 @@ if [ ! -f "${HOME}/.packages/$REPOFILE" -o ! -f "$HOME/.pkg/sources" ];then
   # if repos added ok
   if [ $? -eq 0 ];then
     echo -e "${green}Success:${endcolour} 'noarch' added."
-    echo "Re-running: $SELF $@"
+    echo "Re-running: $SELF $*"
     echo
-    $SELF $@
+    $SELF "$@"
     exit 0
   fi
 
@@ -7444,7 +7452,7 @@ while [ $# != 0 ]; do # get all options ($# means all options)
             [ "$ALINE" ] || break
             [ "$(echo $ALINE| cut -b1)" = '#' ] && continue # skip comment
             [ "$ALINE" = ':' ] && continue  # skip colon
-            if [ "$ALINE" = "- " -o "$ALINE" = " -" -o "$ALINE" != "-" ];then
+            if [ "$ALINE" = "- " ] || [ "$ALINE" = " -" ] || [ "$ALINE" != "-" ];then
               OPTS="${@%-}" #get all opts, without last dash
               OPTS="${OPTS% }" #get all opts, strip last space
               $SELF $OPTS "$ALINE"
@@ -7477,10 +7485,10 @@ while [ $# != 0 ]; do # get all options ($# means all options)
         if [ "$2" = "" ];then
           while true; do
             read ALINE
-            [ "$ALINE" -a "$ALINE" != '-' ] || break
+            [ "$ALINE" ] && [ "$ALINE" != '-' ] || break
             [ "$(echo $ALINE| cut -b1)" = '#' ] && continue # skip comment
             ALINE=`echo $ALINE` #strip spaces
-            if [ "$ALINE" != "-" -a "`$PKGSEARCH "$ALINE"`" != "" ];then
+            if [ "$ALINE" != "-" ] && [ "`$PKGSEARCH "$ALINE"`" != "" ];then
               [ "`is_installed_pkg $ALINE`" = false ] && pkg_get "$ALINE" || \
               pkg_uninstall "$ALINE"
             fi
@@ -7499,82 +7507,82 @@ while [ $# != 0 ]; do # get all options ($# means all options)
 
       # package search
       --all-pkgs|--all)                 [ ! "$2" ] && cat ${HOME}/.packages/${REPOFILE} || cat ${HOME}/.packages/${REPOFILE} | grep "$2"; exit 0;;
-      --search|-s|search|s)             [ ! "$2" ] && search_pkgs          || for x in "$opt"; do [ "$x" -a "$x" != "-" ] && search_pkgs "$x";          done; ;;
-      -ss)                              [ ! "$2" ] && search_fast          || for x in "$opt"; do [ "$x" -a "$x" != "-" ] && search_fast "$x";          done; ;;
-      --search-all|-sa|search-all|sa)   [ ! "$2" ] && search_all_pkgs      || for x in "$opt"; do [ "$x" -a "$x" != "-" ] && search_all_pkgs "$x";      done; ;;
-      -ssa|ssa)                         [ ! "$2" ] && search_all_fast      || for x in "$opt"; do [ "$x" -a "$x" != "-" ] && search_all_fast "$x";      done; ;;
-      --names|-n|names|n)               [ ! "$2" ] && list_pkg_names       || for x in $opt; do [ "$x" -a "$x" != "-" ] && list_pkg_names "$x";         done; ;;
-      --names-exact|-ne|names-exact|ne) [ ! "$2" ] && list_pkg_names       || for x in $opt; do [ "$x" -a "$x" != "-" ] && list_pkg_names "$x\$";       done; ;;
-      --names-all|-na|names-all|na)     [ ! "$2" ] && list_all_pkg_names   || for x in $opt; do [ "$x" -a "$x" != "-" ] && list_all_pkg_names "$x";     done; ;;
---list-installed|list-installed|-li|li) [ ! "$2" ] && list_installed_pkgs  || for x in $opt; do [ "$x" -a "$x" != "-" ] && list_installed_pkgs "$x";    done; exit 0 ;;
+      --search|-s|search|s)             [ ! "$2" ] && search_pkgs          || for x in "$opt"; do [ "$x" ] && [ "$x" != "-" ] && search_pkgs "$x";         done; ;;
+      -ss|ss)                           [ ! "$2" ] && search_fast          || for x in "$opt"; do [ "$x" ] && [ "$x" != "-" ] && search_fast "$x";         done; ;;
+      --search-all|-sa|search-all|sa)   [ ! "$2" ] && search_all_pkgs      || for x in "$opt"; do [ "$x" ] && [ "$x" != "-" ] && search_all_pkgs "$x";     done; ;;
+      -ssa|ssa)                         [ ! "$2" ] && search_all_fast      || for x in "$opt"; do [ "$x" ] && [ "$x" != "-" ] && search_all_fast "$x";     done; ;;
+      --names|-n|names|n)               [ ! "$2" ] && list_pkg_names       || for x in $opt;   do [ "$x" ] && [ "$x" != "-" ] && list_pkg_names "$x";      done; ;;
+      --names-exact|-ne|names-exact|ne) [ ! "$2" ] && list_pkg_names       || for x in $opt;   do [ "$x" ] && [ "$x" != "-" ] && list_pkg_names "$x\$";    done; ;;
+      --names-all|-na|names-all|na)     [ ! "$2" ] && list_all_pkg_names   || for x in $opt;   do [ "$x" ] && [ "$x" != "-" ] && list_all_pkg_names "$x";  done; ;;
+--list-installed|list-installed|-li|li) [ ! "$2" ] && list_installed_pkgs  || for x in $opt;   do [ "$x" ] && [ "$x" != "-" ] && list_installed_pkgs "$x"; done; exit 0 ;;
 --list-downloaded|list-downloaded|-ld|ld) [ ! "$2" ] && list_downloaded_pkgs || list_downloaded_pkgs "$2"; exit 0 ;;
       -LI|LI)                           [ ! "$2" ] && HIDE_BUILTINS=false list_installed_pkgs || HIDE_BUILTINS=false list_installed_pkgs "$2"; exit 0 ;; # list all installed pkgs inc builtins
-  --names-exact-all|-nea|names-exact-all|nea) [ ! "$2" ] && list_all_pkg_names || for x in $opt; do [ "$x" -a "$x" != "-" ] && list_all_pkg_names "$x\$"; done; exit 0 ;;
+  --names-exact-all|-nea|names-exact-all|nea) [ ! "$2" ] && list_all_pkg_names || for x in $opt; do [ "$x" ] && [ "$x" != "-" ] && list_all_pkg_names "$x\$"; done; exit 0 ;;
 
       # get, download, install, remove, pkgs
-      --download|-d|download|d)         [ ! "$2" ] && pkg_download || for x in $opt; do [ "$x" -a "$x" != "-" ] && pkg_download "$x";  done;;
-      --install|-i|install|i)           [ ! "$2" ] && pkg_install  || for x in $opt; do [ "$x" -a "$x" != "-" ] && pkg_install "$x";   done;;
-      --uninstall|-u|uninstall|u)       [ ! "$2" ] && pkg_uninstall|| for x in $opt; do [ "$x" -a "$x" != "-" ] && pkg_uninstall "$x"; done;;
-      --remove|-rm|remove|rm)           [ ! "$2" ] && pkg_remove   || for x in $opt; do [ "$x" -a "$x" != "-" ] && pkg_remove "$x";    done;;
-      --unpack|--extract|unpack|extract)[ ! "$2" ] && pkg_unpack   || for x in $opt; do [ "$x" -a "$x" != "-" ] && pkg_unpack "$x";    done;;
-      --clean|clean)                    [ ! "$2" ] && clean_pkgs   || for x in $opt; do [ "$x" -a "$x" != "-" ] && clean_pkgs "$x";    done;;
-      --get|-g|get|g|--add|add|a)       [ ! "$2" ] && pkg_get      || for x in $opt; do [ "$x" -a "$x" != "-" ] && { choose_pkg "$x"; pkg_get "$x"; }; done ;;
-      --get-only|-go|get-only|go)       [ ! "$2" ] && print_usage get-only || for x in $opt; do if [ "$x" -a "$x" != "-" ];then choose_pkg "$x"; NO_INSTALL=true  pkg_get "$x"; fi; done ;;
+      --download|-d|download|d)         [ ! "$2" ] && pkg_download || for x in $opt; do [ "$x" ] && [ "$x" != "-" ] && pkg_download "$x";  done;;
+      --install|-i|install|i)           [ ! "$2" ] && pkg_install  || for x in $opt; do [ "$x" ] && [ "$x" != "-" ] && pkg_install "$x";   done;;
+      --uninstall|-u|uninstall|u)       [ ! "$2" ] && pkg_uninstall|| for x in $opt; do [ "$x" ] && [ "$x" != "-" ] && pkg_uninstall "$x"; done;;
+      --remove|-rm|remove|rm)           [ ! "$2" ] && pkg_remove   || for x in $opt; do [ "$x" ] && [ "$x" != "-" ] && pkg_remove "$x";    done;;
+      --unpack|--extract|unpack|extract)[ ! "$2" ] && pkg_unpack   || for x in $opt; do [ "$x" ] && [ "$x" != "-" ] && pkg_unpack "$x";    done;;
+      --clean|clean)                    [ ! "$2" ] && clean_pkgs   || for x in $opt; do [ "$x" ] && [ "$x" != "-" ] && clean_pkgs "$x";    done;;
+      --get|-g|get|g|--add|add|a)       [ ! "$2" ] && pkg_get      || for x in $opt; do [ "$x" ] && [ "$x" != "-" ] && { choose_pkg "$x"; pkg_get "$x"; }; done ;;
+      --get-only|-go|get-only|go)       [ ! "$2" ] && print_usage get-only || for x in $opt; do if [ "$x" ] && [ "$x" != "-" ];then choose_pkg "$x"; NO_INSTALL=true  pkg_get "$x"; fi; done ;;
       --delete|-l|delete|l)             [ ! "$2" ] && print_usage delete   || for x in $opt; do [ "$x" = '-' ] && continue; if [ -f "${WORKDIR}/$(basename "$x")" ];then if [ "$ASK" = true ];then echo -n "Remove package `basename $x`$QTAG "; read -n 1 CONFIRM </dev/tty; echo; else CONFIRM=y; fi; [ "$CONFIRM" = "y" ] && rm -v "${WORKDIR}/$(basename "$x")"; else not_found "$x"; fi; done ;; #110213,0.9.1  renamed to --delete|-l
       --delete-all|-la|delete-all|la)   ASK=true; QTAG="?  (y/N)"; if [ "$ASK" = true ];then echo -en "Remove all downloaded packages in ${lightblue}${WORKDIR}/${endcolour}$QTAG"; read -n 1 CONFIRM </dev/tty; echo; else CONFIRM=y; fi; [ "$CONFIRM" = "y" ] && rm -v ${WORKDIR}/*.pet ${WORKDIR}/*.pkg.* ${WORKDIR}/*.sfs ${WORKDIR}/*.tar.* ${WORKDIR}/*.tcz ${WORKDIR}/*.txz ${WORKDIR}/*.tgz ${WORKDIR}/*.deb ${WORKDIR}/*.rpm ${WORKDIR}/*.apk ${WORKDIR}/*.gz ${WORKDIR}/*.xz 2>/dev/null; exit 0;;
-      --install-all|-ia)                list_downloaded_pkgs | while read pkg; do [ "$pkg" -a "$pkg" != "-" ] && pkg_install "$pkg";   done;;
-      --uninstall-all|-ua)              list_installed_pkgs  | while read pkg; do [ "$pkg" -a "$pkg" != "-" ] && pkg_uninstall "$pkg"; done;;
+      --install-all|-ia)                list_downloaded_pkgs | while read pkg; do [ "$pkg" ] && [ "$pkg" != "-" ] && pkg_install "$pkg";   done;;
+      --uninstall-all|-ua)              list_installed_pkgs  | while read pkg; do [ "$pkg" ] && [ "$pkg" != "-" ] && pkg_uninstall "$pkg"; done;;
 
       # pkg status, info
-      --pkg-installed|-pi|installed|pi)   [ ! "$2" ] && is_installed_pkg || for x in $opt; do [ "$x" -a "$x" != "-" ] && is_installed_pkg "$x"; done;;
-      --pkg-entry|-pe|entry|pe)           [ ! "$2" ] && pkg_entry   || for x in $opt; do [ "$x" -a "$x" != "-" ] && pkg_entry "$x";    done;;  # print repo entry, each field on a new line
-      --pkg-status|-ps|status|ps)         [ ! "$2" ] && pkg_status  || for x in $opt; do [ "$x" -a "$x" != "-" ] && pkg_status "$x";   done;;
-      --contents|-c|contents|c)           [ ! "$2" ] && pkg_contents|| for x in $opt; do [ "$x" -a "$x" != "-" ] && pkg_contents "$x" 2>/dev/null; done;;
-      --which|-w|which|w)                 [ ! "$2" ] && which_pkg   || for x in $opt; do [ "$x" -a "$x" != "-" ] && which_pkg "$x";    done;;
-      --which-repo|-wr|which-repo|wr)     [ ! "$2" ] && which_repo  || for x in $opt; do [ "$x" -a "$x" != "-" ] && which_repo "$x";   done;;
-      --pkg-repack|-pr|repack|pr)         [ ! "$2" ] && pkg_repack  || for x in $opt; do [ "$x" -a "$x" != "-" ] && pkg_repack "$x";   done;;
-      --pkg-update|-pu|update|pu)         [ ! "$2" ] && pkg_update  || for x in $opt; do [ "$x" -a "$x" != "-" ] && pkg_update "$x";   done;;
-      --pkg-combine|-pc|pkg-combine|pc)   [ ! "$2" ] && pkg_combine || for x in $opt; do [ "$x" -a "$x" != "-" ] && COMBINE2SFS=false pkg_combine "$x"; done;;
-      --pkg-split|split)                  [ ! "$2" ] && split_pkg   || for x in $opt; do [ "$x" -a "$x" != "-" ] && split_pkg "$x"; done;;
+      --pkg-installed|-pi|installed|pi)   [ ! "$2" ] && is_installed_pkg || for x in $opt; do [ "$x" ] && [ "$x" != "-" ] && is_installed_pkg "$x"; done;;
+      --pkg-entry|-pe|entry|pe)           [ ! "$2" ] && pkg_entry   || for x in $opt; do [ "$x" ] && [ "$x" != "-" ] && pkg_entry "$x";    done;;  # print repo entry, each field on a new line
+      --pkg-status|-ps|status|ps)         [ ! "$2" ] && pkg_status  || for x in $opt; do [ "$x" ] && [ "$x" != "-" ] && pkg_status "$x";   done;;
+      --contents|-c|contents|c)           [ ! "$2" ] && pkg_contents|| for x in $opt; do [ "$x" ] && [ "$x" != "-" ] && pkg_contents "$x" 2>/dev/null; done;;
+      --which|-w|which|w)                 [ ! "$2" ] && which_pkg   || for x in $opt; do [ "$x" ] && [ "$x" != "-" ] && which_pkg "$x";    done;;
+      --which-repo|-wr|which-repo|wr)     [ ! "$2" ] && which_repo  || for x in $opt; do [ "$x" ] && [ "$x" != "-" ] && which_repo "$x";   done;;
+      --pkg-repack|-pr|repack|pr)         [ ! "$2" ] && pkg_repack  || for x in $opt; do [ "$x" ] && [ "$x" != "-" ] && pkg_repack "$x";   done;;
+      --pkg-update|-pu|update|pu)         [ ! "$2" ] && pkg_update  || for x in $opt; do [ "$x" ] && [ "$x" != "-" ] && pkg_update "$x";   done;;
+      --pkg-combine|-pc|pkg-combine|pc)   [ ! "$2" ] && pkg_combine || for x in $opt; do [ "$x" ] && [ "$x" != "-" ] && COMBINE2SFS=false pkg_combine "$x"; done;;
+      --pkg-split|split)                  [ ! "$2" ] && split_pkg   || for x in $opt; do [ "$x" ] && [ "$x" != "-" ] && split_pkg "$x"; done;;
       --pkg-merge|merge)                  [ ! "$2" ] && merge_pkg   || merge_pkg "$2" "$3"; exit 0;;
-      --sfs-combine|-sc|sfs-combine|sc)   [ ! "$2" ] && pkg_combine || for x in $opt; do [ "$x" -a "$x" != "-" ] && COMBINE2SFS=true  pkg_combine "$x"; done;;
-      -PS|PS)                             [ ! "$2" ] && pkg_status  || for x in $opt; do [ "$x" -a "$x" != "-" ] && HIDE_USER_PKGS=false FULL_PKG_STATUS=true pkg_status "$x"; done;; # full pkg status, with sorted deps
+      --sfs-combine|-sc|sfs-combine|sc)   [ ! "$2" ] && pkg_combine || for x in $opt; do [ "$x" ] && [ "$x" != "-" ] && COMBINE2SFS=true  pkg_combine "$x"; done;;
+      -PS|PS)                             [ ! "$2" ] && pkg_status  || for x in $opt; do [ "$x" ] && [ "$x" != "-" ] && HIDE_USER_PKGS=false FULL_PKG_STATUS=true pkg_status "$x"; done;; # full pkg status, with sorted deps
 
       # pkg compiling
-      --pkg-build|-pb|build|pb)           [ ! "$2" ] && pkg_build || for x in $opt; do [ "$x" -a "$x" != "-" ] && PKG_CONFIGURE="$PKG_CONFIGURE" PKG_CFLAGS="$PKG_CFLAGS" pkg_build "$x"; done;;
-   --pkg-build-list|-pbl|build-list|pbl)  [ ! "$2" ] && list_build_scripts || for x in $opt; do [ "$x" -a "$x" != "-" ] && list_build_scripts "$x"; done;;
+      --pkg-build|-pb|build|pb)           [ ! "$2" ] && pkg_build || for x in $opt; do [ "$x" ] && [ "$x" != "-" ] && PKG_CONFIGURE="$PKG_CONFIGURE" PKG_CFLAGS="$PKG_CFLAGS" pkg_build "$x"; done;;
+   --pkg-build-list|-pbl|build-list|pbl)  [ ! "$2" ] && list_build_scripts || for x in $opt; do [ "$x" ] && [ "$x" != "-" ] && list_build_scripts "$x"; done;;
 
       # blacklist and whitelist
-      blacklist)                          [ ! "$2" ] && pkg_blacklist  || for x in $opt; do [ "$x" -a "$x" != "-" ] && pkg_blacklist "$x"; done;;
-      whitelist)                          [ ! "$2" ] && pkg_whitelist  || for x in $opt; do [ "$x" -a "$x" != "-" ] && pkg_whitelist "$x"; done;;
+      blacklist)                          [ ! "$2" ] && pkg_blacklist  || for x in $opt; do [ "$x" ] && [ "$x" != "-" ] && pkg_blacklist "$x"; done;;
+      whitelist)                          [ ! "$2" ] && pkg_whitelist  || for x in $opt; do [ "$x" ] && [ "$x" != "-" ] && pkg_whitelist "$x"; done;;
 
       # dependencies
-      --what-needs|-wn|what-needs|wn)     [ ! "$2" ] && list_dependents; for x in $opt; do [ "$x" -a "$x" != "-" ] && list_dependents "$x";    done ;; # list pkgs depending on $x, not including builtins by default
-      --list-deps|-le|list-deps|le)       [ ! "$2" ] && list_deps; for x in $opt; do [ "$x" -a "$x" != "-" ] && list_deps "$x";                done ;; # list pkg deps, not including builtins
-      --deps|-e|deps|e)                   [ ! "$2" ] && get_deps;  for x in $opt; do [ "$x" -a "$x" != "-" ] && get_deps  "$x";                done ;;
-    --deps-download|-ed|deps-download|ed) [ ! "$2" ] && get_deps;  for x in $opt; do [ "$x" -a "$x" != "-" ] && NO_INSTALL=true get_deps "$x"; done ;;
-      --has-deps|-he|has-deps|he)         [ ! "$2" ] && has_deps;  for x in $opt; do [ "$x" -a "$x" != "-" ] && has_deps  "$x";                done ;;
+      --what-needs|-wn|what-needs|wn)     [ ! "$2" ] && list_dependents; for x in $opt; do [ "$x" ] && [ "$x" != "-" ] && list_dependents "$x";    done ;; # list pkgs depending on $x, not including builtins by default
+      --list-deps|-le|list-deps|le)       [ ! "$2" ] && list_deps; for x in $opt; do [ "$x" ] && [ "$x" != "-" ] && list_deps "$x";                done ;; # list pkg deps, not including builtins
+      --deps|-e|deps|e)                   [ ! "$2" ] && get_deps;  for x in $opt; do [ "$x" ] && [ "$x" != "-" ] && get_deps  "$x";                done ;;
+    --deps-download|-ed|deps-download|ed) [ ! "$2" ] && get_deps;  for x in $opt; do [ "$x" ] && [ "$x" != "-" ] && NO_INSTALL=true get_deps "$x"; done ;;
+      --has-deps|-he|has-deps|he)         [ ! "$2" ] && has_deps;  for x in $opt; do [ "$x" ] && [ "$x" != "-" ] && has_deps  "$x";                done ;;
       --deps-all|-ea|deps-all|ea)         [ ! "$2" ] && get_deps;  [ "$2" != "-" ] && NO_INSTALL=false get_all_deps "$2" ;;
       --deps-check|-ec|deps-check|ec|ldd) [ ! "$2" ] && print_usage deps-check || pkg_ldd_msg "$2" ;;
-      -LE|LE)                             [ ! "$2" ] && HIDE_BUILTINS=false list_deps || for x in $opt; do [ "$x" -a "$x" != "-" ] && HIDE_BUILTINS=false list_deps "$x"; done ;;  # list a pkg deps, including builtins
+      -LE|LE)                             [ ! "$2" ] && HIDE_BUILTINS=false list_deps || for x in $opt; do [ "$x" ] && [ "$x" != "-" ] && HIDE_BUILTINS=false list_deps "$x"; done ;;  # list a pkg deps, including builtins
 
       # repo
       --repo|-r|repo|r)                     [ ! "$2" ] && echo $REPONAME || set_current_repo "$2" ;;
-      --repo-convert|-rc|repo-convert|rc)   [ ! "$2" ] && print_usage repo-convert || for x in $opt; do [ "$x" -a "$x" != "-" ]  && convert_repofile "$x"; done ;;
+      --repo-convert|-rc|repo-convert|rc)   [ ! "$2" ] && print_usage repo-convert || for x in $opt; do [ "$x" ] && [ "$x" != "-" ]  && convert_repofile "$x"; done ;;
       --repo-list|-rl|repo-list|rl)         [ "$2" != "-" ] && repo_list "$2"      ;;
       --repo-info|-ri|repo-info|ri)         [ "$2" != "-" ] && print_repo_info "$2";;
   --repo-file-list|-rfl|repo-file-list|rfl) [ "$2" != "-" ] && repo_file_list "$2" ;;
       --repo-update|-ru|repo-update|ru)     update_repo "$2";;
-      --add-source|add-source)              [ "`echo $2|grep '|'`" = '' -o "$2" = '-' ] && print_usage add-source || add_source "$2";;
-      --add-repo|add-repo)                  [ ! "$2" -o "$2" = '-'  ] && print_usage add-repo || shift; add_repo "$@"; exit 0;;
-      --rm-repo|rm-repo)                    [ ! "$2" -o "$2" = '-'  ] && print_usage rm-repo  || rm_repo "$2"; exit 0;;
+      --add-source|add-source)              [ "`echo $2|grep '|'`" = '' ] || [ "$2" = '-' ] && print_usage add-source || add_source "$2";;
+      --add-repo|add-repo)                  [ ! "$2" ] || [ "$2" = '-'  ] && print_usage add-repo || shift; add_repo "$@"; exit 0;;
+      --rm-repo|rm-repo)                    [ ! "$2" ] || [ "$2" = '-'  ] && print_usage rm-repo  || rm_repo "$2"; exit 0;;
       --update-sources|update-sources)      update_sources ;;
 
       # set repo settings
-      --repo-pkg-scope|-rps|rps|repo-pkg-scope)  if [ "$2" -a "$2" != "-" ];then set_pkg_scope "$2";      else echo "$PKGSCOPE"; fi; exit 0;;
-      --repo-dep-scope|-rds|repo-dep-scope|rds)  if [ "$2" -a "$2" != "-" ];then set_dep_scope "$2";      else echo "$DEPSCOPE"; fi; exit 0;;
-      --bleeding-edge|-be|bleeding-edge|be)      if [ "$2" -a "$2" != "-" ];then set_bleeding_edge "$2";  else echo "$BLEDGE";   fi; exit 0;;
-      --rdep-check|-rdc|rdep-check|rdc)          if [ "$2" -a "$2" != "-" ];then set_recursive_deps "$2"; else echo "$RDCHECK";  fi; exit 0;;
+      --repo-pkg-scope|-rps|rps|repo-pkg-scope)  if [ "$2" ] && [ "$2" != "-" ];then set_pkg_scope "$2";      else echo "$PKGSCOPE"; fi; exit 0;;
+      --repo-dep-scope|-rds|repo-dep-scope|rds)  if [ "$2" ] && [ "$2" != "-" ];then set_dep_scope "$2";      else echo "$DEPSCOPE"; fi; exit 0;;
+      --bleeding-edge|-be|bleeding-edge|be)      if [ "$2" ] && [ "$2" != "-" ];then set_bleeding_edge "$2";  else echo "$BLEDGE";   fi; exit 0;;
+      --rdep-check|-rdc|rdep-check|rdc)          if [ "$2" ] && [ "$2" != "-" ];then set_recursive_deps "$2"; else echo "$RDCHECK";  fi; exit 0;;
 
       # convert
       --deb2pet|deb2pet) [ ! "$2" ] && deb2pet || for x in $opt; do deb2pet "$x"; done ;;
@@ -7592,7 +7600,7 @@ while [ $# != 0 ]; do # get all options ($# means all options)
       # other
       --func-list|func-list)  [ -f $TMPDIR/func_list ] && cat $TMPDIR/func_list || func_list; exit 0;;
       --workdir|workdir)      [ "$2" != "-" ] && set_workdir "$2"; exit $?;;
-      --autoclean|autoclean)  [ "$2" = "yes" -o "$2" = "no" ] && set_autoclean "$2" || { echo "$AUTOCLEAN"; exit 1; } ;;
+      --autoclean|autoclean)  [ "$2" = "yes" ] || [ "$2" = "no" ] && set_autoclean "$2" || { echo "$AUTOCLEAN"; exit 1; } ;;
 
       # usage, help funcs, version info, etc
       --welcome|welcome)          touch $HOME/.pkg/firstrun; first_run; exit 0;;
@@ -7645,7 +7653,7 @@ done
 code=$?
 
 # if AUTOCLEAN=true silently delete all pkgs in WORKDIR that are already installed
-if [ "$AUTOCLEAN" = 'yes' -a "`HIDE_BUILTINS=true list_installed_pkgs`" != '' ];then
+if [ "$AUTOCLEAN" = 'yes' ] && [ "`HIDE_BUILTINS=true list_installed_pkgs`" != '' ];then
   clean_pkgs &>/dev/null
 fi
 

--- a/usr/sbin/ppa2pup_gawk
+++ b/usr/sbin/ppa2pup_gawk
@@ -198,17 +198,9 @@ do
   echo "   ~/.packages/$repo_filename"
   echo
 
-# Warning:
-# We don't need to delete these files because they will be overwritten with IO redirection. 
-# Not deleting them is safer. 
-# Even safer would be to move them to a backup. 
-# for now just remove the /tmp/$repo_filename  since this is lower risk. 
-#  rm /tmp/$repo_filename ~/.packages/$repo_filename &>/dev/null
-rm /tmp/$repo_filename 
-# Also note that if the repo file goes missing this could cause an infinite loop. See: https://gitlab.com/sc0ttj/Pkg/issues/79#note_251505334
-# We need to make the code more robust so that there is no infnite loop!
-  
-			cat "$PACKAGES_PATH" | awk \
+  rm /tmp/$repo_filename &>/dev/null
+
+	cat "$PACKAGES_PATH" | awk \
 'function get_inequality(s){
 	switch(s){
 		case "<":
@@ -231,7 +223,7 @@ rm /tmp/$repo_filename
     return ""
 }
 function fixdepends(s,   p,a,dep_i,dep_split,pkg_i,ver_i,v,ineq,sout) {
-	split(s,a,",") 
+	split(s,a,",")
 	for (p in a) {
 		match(a[p],/^[ \t]*([^ \t]+)[ \t]*(\((.*)\))?/,dep_split)
 		pkg_i = dep_split[1]
@@ -257,7 +249,7 @@ function fixdepends(s,   p,a,dep_i,dep_split,pkg_i,ver_i,v,ineq,sout) {
 /^Pre-Depends:/ { sub(/^Pre-Depends: /,""); PKGDEP=fixdepends($0) "," PKGDEP; }
 /^Description:/ { sub(/^Description: /,""); PKGINFO=substr($0,1,200); }
 /^$/            { print PKG "_" PKGVER "|" PKG "|" PKGVER "||" PKGSECTION "|" PKGSIZE "|" PKGPATH "|" PKGFILE  "|" PKGDEP "|" PKGINFO "|" PKGOS "|" PKGOSVER  ;
-	
+
                   PKG=""; PKGVER=""; PKGSECTION=""; PKGSIZE=""; PKGFILE=""; PKGPATH=""; PKGDEP=""; PKGINFO=""; PKGPRIO="";    }
 ' > /tmp/$repo_filename
 
@@ -275,8 +267,8 @@ function fixdepends(s,   p,a,dep_i,dep_split,pkg_i,ver_i,v,ineq,sout) {
     exit 1
   fi
 
-  mv  /tmp/${repo_filename}_sorted  ~/.packages/$repo_filename 
-   
+  mv  /tmp/${repo_filename}_sorted  ~/.packages/$repo_filename
+
   echo "Success! File created."
   echo
 


### PR DESCRIPTION
## Shellcheck fixes

This PR has lots of fixes based on running `shellcheck` on Pkg:

```
shellcheck --color=always --exclude=SC2086,SC1090,SC1091,SC2155,SC2002,SC2162,SC2006 /usr/sbin/pkg | less
```

Add and remove the SC stuff as needed when fixing different things...

### Fixes in this PR:

- fixes in getting package information:
  - package installed or not
  - package repo
  - package contents
  - package filename (new function `get_pkg_filename`, respects repo fallback order)
  - package versions
- slightly better error checking
  - should be a little bit more reliable
- faster search commands: `pkg s <term>`, `pkg sa <term>`, `pkg ss <term>`, `pkg ssa <term>`
- faster installation and uninstallation of packages
- `pkg what-needs <pkgname>` now much better (faster and more accurate)
  - therefore `pkg rm <pkgname` will be much faster
- fixed output for `pkg PS <pkgname>` (nicely align all deps, not only first 10 lines)
- fixes and updates to the installation of `petbuild`, now using the `generic` branch by default

## Other changes

- fixed various code errors/typos
- fewer sub-shells, a little bit faster
- removed some old code
- simplified some code
- cleaned up long lines, made them < 80 chars

## TODO

- fix `pkg_update`, still not reporting final versions quite right
  - it's kind of respecting fall back order, and also not ..

## In a future PR

Go through again and reduce number of sub-shells, but _keep the code simple_ - no exotic, unreadable stuff.